### PR TITLE
Supervise Bot critical state and cancel its context

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -18,7 +18,7 @@ type Adapter interface {
 	// This may run in a blocking manner til given context is canceled since a new goroutine is allocated for this task.
 	// When the service provider sends message to us, convert that message payload to Input and send to Input channel.
 	// Runner will receive the Input instance and proceed to find and execute corresponding command.
-	Run(context.Context, chan<- Input, chan<- error)
+	Run(context.Context, chan<- Input, func(error))
 
 	// SendMessage sends message to corresponding service provider.
 	// This can be called by scheduled task or in response to input from service provider.

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -4,7 +4,7 @@ import "golang.org/x/net/context"
 
 type DummyAdapter struct {
 	BotTypeValue    BotType
-	RunFunc         func(context.Context, chan<- Input, chan<- error)
+	RunFunc         func(context.Context, chan<- Input, func(error))
 	SendMessageFunc func(context.Context, Output)
 }
 
@@ -12,8 +12,8 @@ func (adapter *DummyAdapter) BotType() BotType {
 	return adapter.BotTypeValue
 }
 
-func (adapter *DummyAdapter) Run(ctx context.Context, input chan<- Input, errCh chan<- error) {
-	adapter.RunFunc(ctx, input, errCh)
+func (adapter *DummyAdapter) Run(ctx context.Context, input chan<- Input, errNotifier func(error)) {
+	adapter.RunFunc(ctx, input, errNotifier)
 }
 
 func (adapter *DummyAdapter) SendMessage(ctx context.Context, output Output) {

--- a/bot.go
+++ b/bot.go
@@ -32,12 +32,12 @@ type Bot interface {
 	// This may run in a blocking manner til given context is canceled since a new goroutine is allocated for this task.
 	// When the service provider sends message to us, convert that message payload to Input and send to Input channel.
 	// Runner will receive the Input instance and proceed to find and execute corresponding command.
-	Run(context.Context, chan<- Input, chan<- error)
+	Run(context.Context, chan<- Input, func(error))
 }
 
 type defaultBot struct {
 	botType          BotType
-	runFunc          func(context.Context, chan<- Input, chan<- error)
+	runFunc          func(context.Context, chan<- Input, func(error))
 	sendMessageFunc  func(context.Context, Output)
 	commands         *Commands
 	userContextCache UserContexts
@@ -107,8 +107,8 @@ func (bot *defaultBot) AppendCommand(command Command) {
 	bot.commands.Append(command)
 }
 
-func (bot *defaultBot) Run(ctx context.Context, receivedInput chan<- Input, errCh chan<- error) {
-	bot.runFunc(ctx, receivedInput, errCh)
+func (bot *defaultBot) Run(ctx context.Context, receivedInput chan<- Input, errNotifier func(error)) {
+	bot.runFunc(ctx, receivedInput, errNotifier)
 }
 
 // NewSuppressedResponseWithNext creates new sarah.CommandResponse instance with no message and next function to continue

--- a/gitter/adapter.go
+++ b/gitter/adapter.go
@@ -35,11 +35,11 @@ func (adapter *Adapter) BotType() sarah.BotType {
 }
 
 // Run fetches all belonging Room and connects to them.
-func (adapter *Adapter) Run(ctx context.Context, receivedMessage chan<- sarah.Input, errCh chan<- error) {
+func (adapter *Adapter) Run(ctx context.Context, receivedMessage chan<- sarah.Input, errNotifier func(error)) {
 	// fetch joined rooms
 	rooms, err := fetchRooms(ctx, adapter.restAPIClient, adapter.config.RetryLimit, adapter.config.RetryInterval)
 	if err != nil {
-		errCh <- sarah.NewBotNonContinuableError(err.Error())
+		errNotifier(sarah.NewBotNonContinuableError(err.Error()))
 		return
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -217,14 +217,16 @@ func Test_botSupervisor(t *testing.T) {
 	err := NewBotNonContinuableError("should stop")
 	errSupervisor(err)
 
-	blocked := true
+	nonBlocking := make(chan bool)
 	go func() {
 		errSupervisor(NewBotNonContinuableError("call after context cancellation should not block"))
-		blocked = false
+		nonBlocking <- true
 	}()
 
-	time.Sleep(100 * time.Millisecond)
-	if blocked {
+	select {
+	case <-nonBlocking:
+		// O.K.
+	case <-time.NewTimer(1 * time.Second).C:
 		t.Error("Call after context cancellation blocks.")
 	}
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -99,7 +99,7 @@ func TestRunner_Run(t *testing.T) {
 	bot.AppendCommandFunc = func(cmd Command) {
 		passedCommand = cmd
 	}
-	bot.RunFunc = func(_ context.Context, _ chan<- Input, _ chan<- error) {
+	bot.RunFunc = func(_ context.Context, _ chan<- Input, _ func(error)) {
 		return
 	}
 
@@ -203,25 +203,7 @@ func Test_executeScheduledTask(t *testing.T) {
 	}
 }
 
-func Test_stopUnrecoverableBot(t *testing.T) {
-	rootCtx := context.Background()
-	botCtx, cancelBot := context.WithCancel(rootCtx)
-	errCh := make(chan error)
-
-	go stopUnrecoverableBot(errCh, cancelBot)
-	if err := botCtx.Err(); err != nil {
-		t.Fatal("Context.Err() should be nil before error is given.")
-	}
-
-	errCh <- NewBotNonContinuableError("")
-
-	time.Sleep(100 * time.Millisecond)
-	if err := botCtx.Err(); err == nil {
-		t.Fatal("Expecting an error at this point.")
-	}
-}
-
-func Test_botSupervisor_botErr(t *testing.T) {
+func Test_botSupervisor(t *testing.T) {
 	rootCxt := context.Background()
 	botCtx, errSupervisor := botSupervisor(rootCxt)
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -205,7 +205,7 @@ func Test_executeScheduledTask(t *testing.T) {
 
 func Test_botSupervisor(t *testing.T) {
 	rootCxt := context.Background()
-	botCtx, errSupervisor := botSupervisor(rootCxt)
+	botCtx, errSupervisor := botSupervisor(rootCxt, "DummyBotType")
 
 	select {
 	case <-botCtx.Done():

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -49,11 +49,11 @@ func (adapter *Adapter) BotType() sarah.BotType {
 	return SLACK
 }
 
-func (adapter *Adapter) Run(ctx context.Context, receivedMessage chan<- sarah.Input, errCh chan<- error) {
+func (adapter *Adapter) Run(ctx context.Context, receivedMessage chan<- sarah.Input, errNotifier func(error)) {
 	for {
 		conn, err := adapter.connect(ctx)
 		if err != nil {
-			errCh <- sarah.NewBotNonContinuableError(err.Error())
+			errNotifier(sarah.NewBotNonContinuableError(err.Error()))
 			return
 		}
 


### PR DESCRIPTION
This addresses #9 by 1) listening to bot context to properly exit on bot termination and 2) providing a function that wraps channel to ensure non-blocking channel send.

As a side effect, implementation changed to encapsulate the Bot context creation and its cancellation in a narrower scope.