### PR TITLE
implement line alerter

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -3,5 +3,5 @@ package sarah
 import "golang.org/x/net/context"
 
 type Alerter interface {
-	Alert(context.Context, BotType, error)
+	Alert(context.Context, BotType, error) error
 }

--- a/alert_test.go
+++ b/alert_test.go
@@ -3,9 +3,9 @@ package sarah
 import "golang.org/x/net/context"
 
 type DummyAlerter struct {
-	AlertFunc func(context.Context, BotType, error)
+	AlertFunc func(context.Context, BotType, error) error
 }
 
-func (alerter *DummyAlerter) Alert(ctx context.Context, botType BotType, err error) {
-	alerter.AlertFunc(ctx, botType, err)
+func (alerter *DummyAlerter) Alert(ctx context.Context, botType BotType, err error) error {
+	return alerter.AlertFunc(ctx, botType, err)
 }

--- a/alerter/line/client.go
+++ b/alerter/line/client.go
@@ -1,0 +1,61 @@
+package line
+
+import (
+	"fmt"
+	"github.com/oklahomer/go-sarah"
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var Endpoint = "https://notify-api.line.me/api/notify"
+
+type Config struct {
+	Token          string        `json:"token" yaml:"token"`
+	RequestTimeout time.Duration `json:"timeout" yaml:"timeout"`
+}
+
+func NewConfig() *Config {
+	return &Config{
+		Token:          "", // Updated on json/yaml unmarshal or by manually
+		RequestTimeout: 3 * time.Second,
+	}
+}
+
+type Client struct {
+	config *Config
+}
+
+func New(config *Config) *Client {
+	return &Client{
+		config: config,
+	}
+}
+
+func (c *Client) Alert(ctx context.Context, botType sarah.BotType, err error) error {
+	reqCtx, cancel := context.WithTimeout(ctx, c.config.RequestTimeout)
+	defer cancel()
+
+	msg := fmt.Sprintf("Critical error on %s: %s.", botType.String(), err.Error())
+	v := url.Values{"message": {msg}}
+	req, err := http.NewRequest("POST", Endpoint, strings.NewReader(v.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.config.Token)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := ctxhttp.Do(reqCtx, http.DefaultClient, req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("response status error. Status: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/alerter/line/client_test.go
+++ b/alerter/line/client_test.go
@@ -1,0 +1,60 @@
+package line
+
+import (
+	"errors"
+	"github.com/jarcoal/httpmock"
+	"golang.org/x/net/context"
+	"testing"
+)
+
+func TestNewConfig(t *testing.T) {
+	config := NewConfig()
+
+	if config == nil {
+		t.Fatal("Config struct is not retuned.")
+	}
+
+	if config.RequestTimeout == 0 {
+		t.Error("Timeout value is not set.")
+	}
+
+	if config.Token != "" {
+		t.Errorf("Token value is set: %s.", config.Token)
+	}
+}
+
+func TestNew(t *testing.T) {
+	config := NewConfig()
+	client := New(config)
+
+	if client == nil {
+		t.Fatal("Client struct is not returned.")
+	}
+
+	if client.config == nil {
+		t.Fatal("Config is not set.")
+	}
+}
+
+func TestClient_Alert(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	returningResponse := &struct {
+		Status  int    `json:"status"`
+		Message string `json:"message"`
+	}{
+		Status:  200,
+		Message: "ok",
+	}
+	responder, _ := httpmock.NewJsonResponder(200, returningResponse)
+	httpmock.RegisterResponder("POST", Endpoint, responder)
+
+	config := NewConfig()
+	client := New(config)
+	err := client.Alert(context.TODO(), "DUMMY", errors.New("message"))
+
+	if err != nil {
+		t.Errorf("Unexpected error is returned: %s.", err.Error())
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -245,7 +245,10 @@ func botSupervisor(runnerCtx context.Context, botType BotType, alerters []Alerte
 					log.Errorf("stop unrecoverable bot. BotType: %s. error: %s.", botType.String(), e.Error())
 					cancel()
 					for _, alerter := range alerters {
-						alerter.Alert(runnerCtx, botType, e)
+						alertErr := alerter.Alert(runnerCtx, botType, e)
+						if alertErr != nil {
+							log.Errorf("failed to send alert via %T: %s", alerter, alertErr.Error())
+						}
 					}
 
 					// Doesn't require return statement at this point.

--- a/runner_test.go
+++ b/runner_test.go
@@ -238,8 +238,9 @@ func Test_botSupervisor(t *testing.T) {
 	alerted := make(chan bool)
 	alerters := []Alerter{
 		&DummyAlerter{
-			AlertFunc: func(_ context.Context, _ BotType, err error) {
+			AlertFunc: func(_ context.Context, _ BotType, err error) error {
 				alerted <- true
+				return nil
 			},
 		},
 	}


### PR DESCRIPTION
#15

Before adding client, modify the interface to return error on alert, so the alert failure can be logged.