### PR TITLE
Return error when skipping blocked input

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -18,7 +18,7 @@ type Adapter interface {
 	// This may run in a blocking manner til given context is canceled since a new goroutine is allocated for this task.
 	// When the service provider sends message to us, convert that message payload to Input and send to Input channel.
 	// Runner will receive the Input instance and proceed to find and execute corresponding command.
-	Run(context.Context, func(Input), func(error))
+	Run(context.Context, func(Input) error, func(error))
 
 	// SendMessage sends message to corresponding service provider.
 	// This can be called by scheduled task or in response to input from service provider.

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -4,7 +4,7 @@ import "golang.org/x/net/context"
 
 type DummyAdapter struct {
 	BotTypeValue    BotType
-	RunFunc         func(context.Context, func(Input), func(error))
+	RunFunc         func(context.Context, func(Input) error, func(error))
 	SendMessageFunc func(context.Context, Output)
 }
 
@@ -12,7 +12,7 @@ func (adapter *DummyAdapter) BotType() BotType {
 	return adapter.BotTypeValue
 }
 
-func (adapter *DummyAdapter) Run(ctx context.Context, enqueueInput func(Input), notifyErr func(error)) {
+func (adapter *DummyAdapter) Run(ctx context.Context, enqueueInput func(Input) error, notifyErr func(error)) {
 	adapter.RunFunc(ctx, enqueueInput, notifyErr)
 }
 

--- a/bot.go
+++ b/bot.go
@@ -32,12 +32,12 @@ type Bot interface {
 	// This may run in a blocking manner til given context is canceled since a new goroutine is allocated for this task.
 	// When the service provider sends message to us, convert that message payload to Input and send to Input channel.
 	// Runner will receive the Input instance and proceed to find and execute corresponding command.
-	Run(context.Context, func(Input), func(error))
+	Run(context.Context, func(Input) error, func(error))
 }
 
 type defaultBot struct {
 	botType          BotType
-	runFunc          func(context.Context, func(Input), func(error))
+	runFunc          func(context.Context, func(Input) error, func(error))
 	sendMessageFunc  func(context.Context, Output)
 	commands         *Commands
 	userContextCache UserContexts
@@ -107,7 +107,7 @@ func (bot *defaultBot) AppendCommand(command Command) {
 	bot.commands.Append(command)
 }
 
-func (bot *defaultBot) Run(ctx context.Context, enqueueInput func(Input), notifyErr func(error)) {
+func (bot *defaultBot) Run(ctx context.Context, enqueueInput func(Input) error, notifyErr func(error)) {
 	bot.runFunc(ctx, enqueueInput, notifyErr)
 }
 

--- a/bot_test.go
+++ b/bot_test.go
@@ -12,7 +12,7 @@ type DummyBot struct {
 	RespondFunc       func(context.Context, Input) error
 	SendMessageFunc   func(context.Context, Output)
 	AppendCommandFunc func(Command)
-	RunFunc           func(context.Context, func(Input), func(error))
+	RunFunc           func(context.Context, func(Input) error, func(error))
 }
 
 func (bot *DummyBot) BotType() BotType {
@@ -31,7 +31,7 @@ func (bot *DummyBot) AppendCommand(command Command) {
 	bot.AppendCommandFunc(command)
 }
 
-func (bot *DummyBot) Run(ctx context.Context, enqueueInput func(Input), notifyErr func(error)) {
+func (bot *DummyBot) Run(ctx context.Context, enqueueInput func(Input) error, notifyErr func(error)) {
 	bot.RunFunc(ctx, enqueueInput, notifyErr)
 }
 
@@ -251,7 +251,7 @@ func TestDefaultBot_Respond_Abort(t *testing.T) {
 func TestDefaultBot_Run(t *testing.T) {
 	adapterProcessed := false
 	bot := &defaultBot{
-		runFunc: func(_ context.Context, _ func(Input), _ func(error)) {
+		runFunc: func(_ context.Context, _ func(Input) error, _ func(error)) {
 			adapterProcessed = true
 		},
 	}
@@ -259,7 +259,7 @@ func TestDefaultBot_Run(t *testing.T) {
 	rootCtx := context.Background()
 	botCtx, cancelBot := context.WithCancel(rootCtx)
 	defer cancelBot()
-	bot.Run(botCtx, func(_ Input) {}, func(_ error) {})
+	bot.Run(botCtx, func(_ Input) error { return nil }, func(_ error) {})
 
 	if adapterProcessed == false {
 		t.Error("Adapter.Run is not called.")

--- a/error.go
+++ b/error.go
@@ -1,5 +1,7 @@
 package sarah
 
+import "fmt"
+
 // BotNonContinuableError represents critical error that Bot can't continue its operation.
 // When Runner receives this, it must stop corresponding Bot, and should inform administrator by available mean.
 type BotNonContinuableError struct {
@@ -14,4 +16,28 @@ func (e BotNonContinuableError) Error() string {
 // NewBotNonContinuableError creates and return new BotNonContinuableError instance.
 func NewBotNonContinuableError(errorContent string) error {
 	return &BotNonContinuableError{err: errorContent}
+}
+
+// BlockedInputError indicates incoming input is blocked due to lack of resource.
+// Excessive increase in message volume may result in this error.
+// When this error occurs, Runner does not wait to enqueue input, but just skip the overflowing message and proceed.
+//
+// Possible cure includes having more workers and/or more worker queue size,
+// but developers MUST aware that this modification may cause more concurrent Command.Execute and Bot.SendMessage operation.
+// With that said, increase workers by setting bigger number to worker.Config.WorkerNum to allow more concurrent executions and minimize the delay;
+// increase worker queue size by setting bigger number to worker.Config.QueueSize to allow delay and have same concurrent execution number.
+type BlockedInputError struct {
+	ContinuationCount int
+}
+
+// Error returns the detailed error about this blocking situation including the number of continuous occurrence.
+// Do err.(*BlockedInputError).ContinuationCount to get the number of continuous occurrence.
+// e.g. log if the remainder of this number divided by N is 0 to avoid excessive logging.
+func (e BlockedInputError) Error() string {
+	return fmt.Sprintf("continuously failed to enqueue input (%d continuation)", e.ContinuationCount)
+}
+
+// NewBlockedInputError creates and return new BlockedInputError instance.
+func NewBlockedInputError(i int) error {
+	return &BlockedInputError{ContinuationCount: i}
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,34 @@
+package sarah
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestNewBlockedInputError(t *testing.T) {
+	i := 123
+	err := NewBlockedInputError(i)
+
+	if err == nil {
+		t.Fatal("Instance of BlockedInputError is not returned.")
+	}
+
+	if _, ok := err.(*BlockedInputError); !ok {
+		t.Fatalf("Returned value is not instance of BBlockedInputError: %#v", err)
+	}
+
+	concreteErr := err.(*BlockedInputError)
+	if concreteErr.ContinuationCount != i {
+		t.Errorf("Returned instance has different count than expected one. Expected: %d. Returned: %d.", i, concreteErr.ContinuationCount)
+	}
+}
+
+func TestBlockedInputError_Error(t *testing.T) {
+	i := 123
+	err := NewBlockedInputError(i)
+
+	if !strings.Contains(err.Error(), strconv.Itoa(i)) {
+		t.Errorf("Returned string does not contain the count of error occurrence: %s.", err.Error())
+	}
+}

--- a/gitter/adapter.go
+++ b/gitter/adapter.go
@@ -35,7 +35,7 @@ func (adapter *Adapter) BotType() sarah.BotType {
 }
 
 // Run fetches all belonging Room and connects to them.
-func (adapter *Adapter) Run(ctx context.Context, enqueueInput func(sarah.Input), notifyErr func(error)) {
+func (adapter *Adapter) Run(ctx context.Context, enqueueInput func(sarah.Input) error, notifyErr func(error)) {
 	// fetch joined rooms
 	rooms, err := fetchRooms(ctx, adapter.restAPIClient, adapter.config.RetryLimit, adapter.config.RetryInterval)
 	if err != nil {
@@ -63,7 +63,7 @@ func (adapter *Adapter) SendMessage(ctx context.Context, output sarah.Output) {
 	}
 }
 
-func (adapter *Adapter) runEachRoom(ctx context.Context, room *Room, enqueueInput func(sarah.Input)) {
+func (adapter *Adapter) runEachRoom(ctx context.Context, room *Room, enqueueInput func(sarah.Input) error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -105,7 +105,7 @@ func fetchRooms(ctx context.Context, fetcher RoomsFetcher, retrial uint, interva
 	return rooms, err
 }
 
-func receiveMessageRecursive(messageReceiver MessageReceiver, enqueueInput func(sarah.Input)) error {
+func receiveMessageRecursive(messageReceiver MessageReceiver, enqueueInput func(sarah.Input) error) error {
 	log.Infof("start receiving message")
 	for {
 		message, err := messageReceiver.Receive()

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -49,7 +49,7 @@ func (adapter *Adapter) BotType() sarah.BotType {
 	return SLACK
 }
 
-func (adapter *Adapter) Run(ctx context.Context, enqueueInput func(sarah.Input), notifyErr func(error)) {
+func (adapter *Adapter) Run(ctx context.Context, enqueueInput func(sarah.Input) error, notifyErr func(error)) {
 	for {
 		conn, err := adapter.connect(ctx)
 		if err != nil {
@@ -127,7 +127,7 @@ func (adapter *Adapter) connect(ctx context.Context) (rtmapi.Connection, error) 
 	return connectRTM(ctx, adapter.client, rtmSession, adapter.config.RetryLimit, adapter.config.RetryInterval)
 }
 
-func (adapter *Adapter) receivePayload(connCtx context.Context, payloadReceiver rtmapi.PayloadReceiver, tryPing chan<- struct{}, enqueueInput func(sarah.Input)) {
+func (adapter *Adapter) receivePayload(connCtx context.Context, payloadReceiver rtmapi.PayloadReceiver, tryPing chan<- struct{}, enqueueInput func(sarah.Input) error) {
 	for {
 		select {
 		case <-connCtx.Done():


### PR DESCRIPTION
To let caller Adapter/Bot have the ability to handle blocking sarah.Input state, return specific error instance on enqueueing operation.