### PR TITLE
Recover when alert panics

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -1,10 +1,63 @@
 package sarah
 
-import "golang.org/x/net/context"
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"strings"
+)
 
 // Alerter can be used to report Bot's critical state to developer/administrator.
 // Anything that implements this interface can be registered as Alerter via Runner.RegisterAlerter.
 type Alerter interface {
 	// Alert sends notification to developer/administrator so one may notify Bot's critical state.
 	Alert(context.Context, BotType, error) error
+}
+
+type alertErrs []error
+
+func (e *alertErrs) appendError(err error) {
+	*e = append(*e, err)
+}
+
+func (e *alertErrs) isEmpty() bool {
+	return len(*e) == 0
+}
+
+// Error returns stringified form of all stored errors.
+func (e *alertErrs) Error() string {
+	errs := []string{}
+	for _, err := range *e {
+		errs = append(errs, err.Error())
+	}
+	return strings.Join(errs, "\n")
+}
+
+type alerters []Alerter
+
+func (a *alerters) appendAlerter(alerter Alerter) {
+	*a = append(*a, alerter)
+}
+
+func (a *alerters) alertAll(ctx context.Context, botType BotType, err error) error {
+	alertErrs := &alertErrs{}
+	for _, alerter := range *a {
+		// Considering the irregular state of Bot's lifecycle and importance of alert,
+		// it is safer to be panic-proof.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					alertErrs.appendError(fmt.Errorf("panic on Alerter.Alert: %#v", r))
+				}
+			}()
+			err := alerter.Alert(ctx, botType, err)
+			if err != nil {
+				alertErrs.appendError(err)
+			}
+		}()
+	}
+
+	if alertErrs.isEmpty() {
+		return nil
+	}
+	return alertErrs
 }

--- a/alert_test.go
+++ b/alert_test.go
@@ -1,6 +1,11 @@
 package sarah
 
-import "golang.org/x/net/context"
+import (
+	"errors"
+	"golang.org/x/net/context"
+	"strings"
+	"testing"
+)
 
 type DummyAlerter struct {
 	AlertFunc func(context.Context, BotType, error) error
@@ -8,4 +13,96 @@ type DummyAlerter struct {
 
 func (alerter *DummyAlerter) Alert(ctx context.Context, botType BotType, err error) error {
 	return alerter.AlertFunc(ctx, botType, err)
+}
+
+func TestAlertErrs_appendError(t *testing.T) {
+	e := errors.New("Foo")
+	errs := &alertErrs{}
+	errs.appendError(e)
+
+	if len(*errs) != 1 {
+		t.Errorf("Expected 1 error to be stored, but was %d.", len(*errs))
+	}
+}
+
+func TestAlertErrs_isEmpty(t *testing.T) {
+	errs := &alertErrs{}
+	if !errs.isEmpty() {
+		t.Error("Expected to be true, but was not.")
+	}
+
+	errs = &alertErrs{errors.New("Foo")}
+	if errs.isEmpty() {
+		t.Error("Expected to be false, but was not.")
+	}
+}
+
+func TestAlertErrs_Error(t *testing.T) {
+	testSets := []struct {
+		errs []error
+	}{
+		{errs: nil},
+		{errs: []error{errors.New("single error string")}},
+		{errs: []error{errors.New("1st error string"), errors.New("2nd error string")}},
+	}
+
+	for i, testSet := range testSets {
+		errs := []string{}
+		for _, err := range testSet.errs {
+			errs = append(errs, err.Error())
+		}
+		expected := strings.Join(errs, "\n")
+
+		e := &alertErrs{}
+		*e = testSet.errs
+		if e.Error() != expected {
+			t.Errorf("Expected error is not returned on test %d: %s", i, e.Error())
+		}
+	}
+}
+
+func TestAlerters_appendAlerter(t *testing.T) {
+	a := &alerters{}
+	impl := &DummyAlerter{}
+	a.appendAlerter(impl)
+
+	if len(*a) != 1 {
+		t.Fatalf("Expected 1 Alerter to be stored, but was %d.", len(*a))
+	}
+}
+
+func TestAlerters_alertAll(t *testing.T) {
+	a := &alerters{}
+	err := a.alertAll(context.TODO(), "FOO", errors.New("error"))
+	if err != nil {
+		t.Errorf("Expected no error to be returned, but got %s.", err.Error())
+	}
+
+	a = &alerters{
+		&DummyAlerter{
+			AlertFunc: func(_ context.Context, _ BotType, _ error) error {
+				panic("PANIC!!")
+			},
+		},
+		&DummyAlerter{
+			AlertFunc: func(_ context.Context, _ BotType, _ error) error {
+				return errors.New("ERROR!!")
+			},
+		},
+		&DummyAlerter{
+			AlertFunc: func(_ context.Context, _ BotType, _ error) error {
+				return nil
+			},
+		},
+	}
+
+	err = a.alertAll(context.TODO(), "FOO", errors.New("error"))
+	if err == nil {
+		t.Fatal("Expected error to be returned")
+	}
+	if e, ok := err.(*alertErrs); !ok {
+		t.Fatalf("Expected error type of *alertErrs, but was %T.", err)
+	} else if len(*e) != 2 {
+		t.Errorf("Expected 2 errors to be stored: %#v.", err)
+	}
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -71,18 +71,18 @@ func TestRunner_RegisterBot(t *testing.T) {
 
 func TestRunner_RegisterAlerter(t *testing.T) {
 	runner := &Runner{}
-	runner.alerters = []Alerter{}
+	runner.alerters = &alerters{}
 
 	alerter := &DummyAlerter{}
 	runner.RegisterAlerter(alerter)
 
 	registeredAlerters := runner.alerters
-	if len(registeredAlerters) != 1 {
-		t.Fatalf("One and only one alerter should be registered, but actual number was %d.", len(registeredAlerters))
+	if len(*registeredAlerters) != 1 {
+		t.Fatalf("One and only one alerter should be registered, but actual number was %d.", len(*registeredAlerters))
 	}
 
-	if registeredAlerters[0] != alerter {
-		t.Fatalf("Passed alerter is not registered: %#v.", registeredAlerters[0])
+	if (*registeredAlerters)[0] != alerter {
+		t.Fatalf("Passed alerter is not registered: %#v.", (*registeredAlerters)[0])
 	}
 }
 
@@ -236,7 +236,12 @@ func Test_executeScheduledTask(t *testing.T) {
 func Test_botSupervisor(t *testing.T) {
 	rootCxt := context.Background()
 	alerted := make(chan bool)
-	alerters := []Alerter{
+	alerters := &alerters{
+		&DummyAlerter{
+			AlertFunc: func(_ context.Context, _ BotType, err error) error {
+				panic("Panic should not affect other alerters' behavior.")
+			},
+		},
 		&DummyAlerter{
 			AlertFunc: func(_ context.Context, _ BotType, err error) error {
 				alerted <- true


### PR DESCRIPTION
Considering the irregular state of Bot's lifecycle and importance of alert, it is safer to be panic-proof.