### PR TITLE
Use functional options for Runner construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,7 @@ func main() {
         // Initialize Runner
         config := sarah.NewConfig()
         config.PluginConfigRoot = "path/to/plugin/configuration" // can be set manually or with (json|yaml).Unmarshal
-        runner := sarah.NewRunner(config)
-
-        // Register declared bot.
-        runner.RegisterBot(slackBot)
+        runner, _ := sarah.NewRunner(config, sarah.WithBot(slackBot))
 
         // Start interaction
         rootCtx := context.Background()

--- a/runner.go
+++ b/runner.go
@@ -62,18 +62,40 @@ func NewRunner(config *Config, options ...RunnerOption) (*Runner, error) {
 	return runner, nil
 }
 
+// RunnerOption defines function that Runner's functional option must satisfy.
 type RunnerOption func(runner *Runner) error
 
+// RunnerOptions stashes RunnerOption for later use, NewRunner.
+//
+// On typical development, especially a process consists of multiple Bots and Commands, each construction requires more lines of codes.
+// In that case RunnerOptions becomes a handy helper to stash RunnerOption.
+//
+//  options := NewRunnerOptions()
+//  // 5-10 lines of codes to configure Slack bot.
+//  slackBot, _ := sarah.NewBot(slack.NewAdapter(slackConfig), sarah.BotWithStorage(storage))
+//  options.Append(sarah.WithBot(slackBot))
+//
+//  // Here comes other 5-10 codes to configure another bot
+//  myBot, _ := NewMyBot(...)
+//
+//  // Some more codes to register Commands / ScheduledTasks
+//  myTask := customizedTask()
+//  options.Append(sarah.WithScheduledTask(myTask))
+//
+//  runner, _ := NewRunner(sarah.NewConfig(), options.Arg())
 type RunnerOptions []RunnerOption
 
+// NewRunnerOptions creates and returns new RunnerOptions instance.
 func NewRunnerOptions() *RunnerOptions {
 	return &RunnerOptions{}
 }
 
+// Append adds given RunnerOption to internal stash.
 func (options *RunnerOptions) Append(opt RunnerOption) {
 	*options = append(*options, opt)
 }
 
+// Arg returns stashed RunnerOptions in a form that can be directly fed to NewRunner's second argument.
 func (options *RunnerOptions) Arg() RunnerOption {
 	return func(runner *Runner) error {
 		for _, opt := range *options {
@@ -87,6 +109,7 @@ func (options *RunnerOptions) Arg() RunnerOption {
 	}
 }
 
+// WithBot creates RunnerOption with given Bot implementation.
 func WithBot(bot Bot) RunnerOption {
 	return func(runner *Runner) error {
 		runner.bots = append(runner.bots, bot)
@@ -94,6 +117,7 @@ func WithBot(bot Bot) RunnerOption {
 	}
 }
 
+// WithScheduledTask creates RunnerOperation with given ScheduledTask.
 func WithScheduledTask(botType BotType, task ScheduledTask) RunnerOption {
 	return func(runner *Runner) error {
 		tasks, ok := runner.scheduledTasks[botType]
@@ -105,6 +129,7 @@ func WithScheduledTask(botType BotType, task ScheduledTask) RunnerOption {
 	}
 }
 
+// WithAlerter creates RunnerOperation with given Alerter.
 func WithAlerter(alerter Alerter) RunnerOption {
 	return func(runner *Runner) error {
 		runner.alerters.appendAlerter(alerter)

--- a/runner.go
+++ b/runner.go
@@ -112,28 +112,6 @@ func WithAlerter(alerter Alerter) RunnerOption {
 	}
 }
 
-// RegisterBot register given Bot implementation to Runner instance
-func (runner *Runner) RegisterBot(bot Bot) {
-	runner.bots = append(runner.bots, bot)
-}
-
-// RegisterScheduledTask register given ScheduledTask implementation to Runner.
-// Once Runner.Run is called, registered tasks are scheduled and will be executed as configured.
-func (runner *Runner) RegisterScheduledTask(botType BotType, task ScheduledTask) {
-	tasks, ok := runner.scheduledTasks[botType]
-	if !ok {
-		tasks = []ScheduledTask{}
-	}
-
-	runner.scheduledTasks[botType] = append(tasks, task)
-}
-
-// RegisterAlerter register given Alerter implementation to Runner instance.
-// Developer can register as many Alerters as one wishes.
-func (runner *Runner) RegisterAlerter(alerter Alerter) {
-	runner.alerters.appendAlerter(alerter)
-}
-
 // Run starts Bot interaction.
 // At this point Runner starts its internal workers and schedulers, runs each bot, and starts listening to incoming messages.
 func (runner *Runner) Run(ctx context.Context) {

--- a/runner_test.go
+++ b/runner_test.go
@@ -204,41 +204,6 @@ func TestWithAlerter(t *testing.T) {
 		t.Fatalf("Passed alerter is not registered: %#v.", (*registeredAlerters)[0])
 	}
 }
-
-func TestRunner_RegisterBot(t *testing.T) {
-	runner := &Runner{}
-	runner.bots = []Bot{}
-
-	bot := &DummyBot{}
-	runner.RegisterBot(bot)
-
-	registeredBots := runner.bots
-	if len(registeredBots) != 1 {
-		t.Fatalf("One and only one bot should be registered, but actual number was %d.", len(registeredBots))
-	}
-
-	if registeredBots[0] != bot {
-		t.Fatalf("Passed bot is not registered: %#v.", registeredBots[0])
-	}
-}
-
-func TestRunner_RegisterAlerter(t *testing.T) {
-	runner := &Runner{}
-	runner.alerters = &alerters{}
-
-	alerter := &DummyAlerter{}
-	runner.RegisterAlerter(alerter)
-
-	registeredAlerters := runner.alerters
-	if len(*registeredAlerters) != 1 {
-		t.Fatalf("One and only one alerter should be registered, but actual number was %d.", len(*registeredAlerters))
-	}
-
-	if (*registeredAlerters)[0] != alerter {
-		t.Fatalf("Passed alerter is not registered: %#v.", (*registeredAlerters)[0])
-	}
-}
-
 func TestRunner_Run(t *testing.T) {
 	var botType BotType = "myBot"
 
@@ -312,26 +277,6 @@ func TestRunner_Run(t *testing.T) {
 		// O.K.
 	case <-time.NewTimer(10 * time.Second).C:
 		t.Error("Runner is not finished.")
-	}
-}
-
-func TestRunner_RegisterScheduledTask(t *testing.T) {
-	runner := &Runner{
-		scheduledTasks: make(map[BotType][]ScheduledTask),
-	}
-
-	task := &DummyScheduledTask{
-		IdentifierValue: "foo",
-	}
-
-	var botType BotType = "Buzz"
-	runner.RegisterScheduledTask(botType, task)
-	tasks, ok := runner.scheduledTasks[botType]
-	if !ok {
-		t.Fatal("Expected BotType is not stashed as key.")
-	}
-	if len(tasks) != 1 && tasks[0] != task {
-		t.Errorf("Expected task is not stashed: %#v", tasks)
 	}
 }
 


### PR DESCRIPTION
Currenlty ```Runner``` has individual instance methods to setup behavior such as ```Runner.RegisterBot```, ```Runner.RegisterScheduledTask``` and ```Runner.RegisterAlerter```. These methods can be called after ```Runner``` construction before / after call of ```Runner.Run```. However ```Runner.RegisterBot``` and ```Runner.RegisterScheduledTask``` only works when these are called before ```Runner.Run``` because these are methods to setup ```Runner.Run```'s behavior.
So instead of keep providing those methods that can technically be called at any moment while only effective **before** ```Runner.Run``` call, provide and use functional option on ```Runner``` construction so that behavior can only be specified before ```Runner.Run```.