### PR TITLE
Let Command.Match checks against whole Input

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -173,7 +173,7 @@ func TestDefaultBot_Respond_WithContextButMessage(t *testing.T) {
 		return nil, nil
 	}
 	command := &DummyCommand{
-		MatchFunc: func(_ string) bool {
+		MatchFunc: func(_ Input) bool {
 			return true
 		},
 		ExecuteFunc: func(_ context.Context, _ Input) (*CommandResponse, error) {

--- a/command_test.go
+++ b/command_test.go
@@ -106,6 +106,26 @@ func TestCommandPropsBuilder_InputExample(t *testing.T) {
 	}
 }
 
+func TestCommandPropsBuilder_MatchPattern(t *testing.T) {
+	builder := &CommandPropsBuilder{props: &CommandProps{}}
+	builder.MatchPattern(regexp.MustCompile(`^\.echo`))
+
+	if !builder.props.matchFunc(&DummyInput{MessageValue: ".echo"}) {
+		t.Error("Expected true to return, but did not.")
+	}
+}
+
+func TestCommandPropsBuilder_MatchFunc(t *testing.T) {
+	builder := &CommandPropsBuilder{props: &CommandProps{}}
+	builder.MatchFunc(func(input Input) bool {
+		return regexp.MustCompile(`^\.echo`).MatchString(input.Message())
+	})
+
+	if !builder.props.matchFunc(&DummyInput{MessageValue: ".echo"}) {
+		t.Error("Expected true to return, but did not.")
+	}
+}
+
 func TestCommandPropsBuilder_Build(t *testing.T) {
 	builder := &CommandPropsBuilder{props: &CommandProps{}}
 	if _, err := builder.Build(); err == nil {

--- a/runner_test.go
+++ b/runner_test.go
@@ -285,9 +285,11 @@ func TestRunner_Run(t *testing.T) {
 
 	// Prepare command to be configured on the fly
 	commandProps := &CommandProps{
-		botType:      botType,
-		identifier:   "dummy",
-		matchPattern: regexp.MustCompile(`^\.echo`),
+		botType:    botType,
+		identifier: "dummy",
+		matchFunc: func(input Input) bool {
+			return regexp.MustCompile(`^\.echo`).MatchString(input.Message())
+		},
 		commandFunc: func(_ context.Context, _ Input, _ ...CommandConfig) (*CommandResponse, error) {
 			return nil, nil
 		},

--- a/task_test.go
+++ b/task_test.go
@@ -51,20 +51,20 @@ func TestNewScheduledTaskPropsBuilder(t *testing.T) {
 
 func TestScheduledTaskPropsBuilder_BotType(t *testing.T) {
 	var botType BotType = "dummy"
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	builder.BotType(botType)
 
-	if builder.botType != botType {
+	if builder.props.botType != botType {
 		t.Error("Provided BotType was not set.")
 	}
 }
 
 func TestScheduledTaskPropsBuilder_Identifier(t *testing.T) {
 	id := "overWhelmedWithTasks"
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	builder.Identifier(id)
 
-	if builder.identifier != id {
+	if builder.props.identifier != id {
 		t.Fatal("Supplied id is not set.")
 	}
 }
@@ -74,10 +74,10 @@ func TestScheduledTaskPropsBuilder_Func(t *testing.T) {
 	taskFunc := func(_ context.Context) ([]*ScheduledTaskResult, error) {
 		return []*ScheduledTaskResult{{Content: res}}, nil
 	}
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	builder.Func(taskFunc)
 
-	actualRes, err := builder.taskFunc(context.TODO())
+	actualRes, err := builder.props.taskFunc(context.TODO())
 	if err != nil {
 		t.Fatalf("Unexpected error returned: %s.", err.Error())
 	}
@@ -89,20 +89,20 @@ func TestScheduledTaskPropsBuilder_Func(t *testing.T) {
 
 func TestScheduledTaskPropsBuilder_Schedule(t *testing.T) {
 	schedule := "@daily"
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	builder.Schedule(schedule)
 
-	if builder.schedule != schedule {
+	if builder.props.schedule != schedule {
 		t.Fatal("Supplied schedule is not set.")
 	}
 }
 
 func TestScheduledTaskPropsBuilder_DefaultDestination(t *testing.T) {
 	destination := "dest"
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	builder.DefaultDestination(destination)
 
-	if builder.defaultDestination != destination {
+	if builder.props.defaultDestination != destination {
 		t.Fatal("Supplied destination is not set.")
 	}
 }
@@ -119,24 +119,24 @@ func TestScheduledTaskPropsBuilder_ConfigurableFunc(t *testing.T) {
 			},
 		}, nil
 	}
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	builder.ConfigurableFunc(config, taskFunc)
 
-	if builder.config != config {
+	if builder.props.config != config {
 		t.Fatal("Supplied config is not set.")
 	}
-	if builder.taskFunc == nil {
+	if builder.props.taskFunc == nil {
 		t.Fatal("Supplied function is not set.")
 	}
 
-	_, err := builder.taskFunc(context.TODO(), config)
+	_, err := builder.props.taskFunc(context.TODO(), config)
 	if err != nil {
 		t.Fatalf("Unexpected error returned: %s.", err.Error())
 	}
 }
 
 func TestScheduledTaskPropsBuilder_Build(t *testing.T) {
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	_, err := builder.Build()
 	if err != ErrTaskInsufficientArgument {
 		t.Fatalf("Expected error is not returned: %#v.", err)
@@ -171,7 +171,7 @@ func TestScheduledTaskPropsBuilder_Build(t *testing.T) {
 }
 
 func TestScheduledTaskPropsBuilder_MustBuild(t *testing.T) {
-	builder := &ScheduledTaskPropsBuilder{}
+	builder := &ScheduledTaskPropsBuilder{props: &ScheduledTaskProps{}}
 	builder.BotType("dummyBot").
 		Identifier("dummy").
 		Func(func(_ context.Context) ([]*ScheduledTaskResult, error) {
@@ -189,7 +189,7 @@ func TestScheduledTaskPropsBuilder_MustBuild(t *testing.T) {
 
 	builder.Schedule("@daily")
 	props := builder.MustBuild()
-	if props.identifier != builder.identifier {
+	if props.identifier != builder.props.identifier {
 		t.Error("Provided identifier is not set.")
 	}
 }


### PR DESCRIPTION
Current ```Command``` implementation only checks against incoming user message content, ```Input.Message()```, to see if the ```Command``` matches to user input. It works O.K. as long as checking logic is simple enough so a tiny regular expression, ```return regexp.MustCompile(`^\.echo`).MatchString(incomingMessage)```, does all the checking.

However this spec limits the ability to check against one or combination of ```Input```'s value. e.g. See if a particular user is sending a message starting with particular prefix in particular time range.

TODO:
- [x] Modify ```Command``` interface's ```Match``` function to accept ```Input``` instead of ```Input.Mesasge()``` value.
- [x] Other than current ```CommandPropsBuilder.MatchPattern```, let ```CommandPropsBuilder``` accept a customized function that handles the matching.