### PR TITLE
Add slack message handler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ func main() {
         configBuf, _ := ioutil.ReadFile("/path/to/adapter/config.yaml")
         slackConfig := slack.NewConfig() // config struct is returned with default settings.
         yaml.Unmarshal(configBuf, slackConfig)
-        sarah.NewBot(slack.NewAdapter(slackConfig))
+        slackAdapter, _ := slack.NewAdapter(slackConfig)
+        sarah.NewBot(slackAdapter)
 }
 ```
 
@@ -249,7 +250,8 @@ func main() {
         slackConfig := slack.NewConfig()
         yaml.Unmarshal(configBuf, slackConfig)
         storage := sarah.NewUserContextStorage(sarah.NewCacheConfig())
-        slackBot, _ := sarah.NewBot(slack.NewAdapter(slackConfig), sarah.BotWithStorage(storage))
+        slackAdapter, _ := slack.NewAdapter(slackConfig)
+        slackBot, _ := sarah.NewBot(slackAdapter, sarah.BotWithStorage(storage))
         options.Append(sarah.WithBot(slackBot))
 
         // Add option to utilize hello command.

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -33,6 +33,59 @@ func WithSlackClient(client SlackClient) AdapterOption {
 	}
 }
 
+// WithPayloadHandler creates AdapterOption with given function that is called when payload is sent from Slack via WebSocket connection.
+//
+// Slack's RTM API defines relatively large amount of payload types.
+// To have better user experience, developers may provide customized callback function to handle received payload.
+//
+// Developer may wish to have direct access to SlackClient to post some sort of message to Slack via Web API.
+// In that case, wrap this function like below so the SlackClient can be accessed within its scope.
+//
+//  // Setup golack instance, which implements SlackClient interface.
+//  golackConfig := golack.NewConfig()
+//  golackConfig.Token = "XXXXXXX"
+//  slackClient := golack.New(golackConfig)
+//
+//  slackConfig := slack.NewConfig()
+//  payloadHandler := func(connCtx context.Context, config *Config, paylad rtmapi.DecodedPayload, enqueueInput func(sarah.Input) error) {
+//    switch p := payload.(type) {
+//    case *rtmapi.PinAdded:
+//      // Do something with pre-defined SlackClient
+//      // slackClient.PostMessage(connCtx, ...)
+//
+//    case *rtmapi.Message:
+//      // Convert RTM specific message to one that satisfies sarah.Input interface.
+//      input := &MessageInput{event: p}
+//
+//      trimmed := strings.TrimSpace(input.Message())
+//      if config.HelpCommand != "" && trimmed == config.HelpCommand {
+//        // Help command
+//        help := sarah.NewHelpInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
+//        enqueueInput(help)
+//      } else if config.AbortCommand != "" && trimmed == config.AbortCommand {
+//        // Abort command
+//        abort := sarah.NewAbortInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
+//        enqueueInput(abort)
+//      } else {
+//        // Regular input
+//        enqueueInput(input)
+//      }
+//
+//    default:
+//      log.Debugf("payload given, but no corresponding action is defined. %#v", p)
+//
+//    }
+//  }
+//
+//  slackAdapter, _ := slack.NewAdapter(slackConfig, slack.WithSlackClient(slackClient), slack.WithPayloadHandler(payloadHandler))
+//  slackBot, _ := sarah.NewBot(slackAdapter)
+func WithPayloadHandler(fnc func(context.Context, *Config, rtmapi.DecodedPayload, func(sarah.Input) error)) AdapterOption {
+	return func(adapter *Adapter) error {
+		adapter.payloadHandler = fnc
+		return nil
+	}
+}
+
 // Adapter internally calls Slack Rest API and Real Time Messaging API to offer Bot developers easy way to communicate with Slack.
 //
 // This implements sarah.Adapter interface, so this instance can be fed to sarah.Runner instance as below.
@@ -48,16 +101,18 @@ func WithSlackClient(client SlackClient) AdapterOption {
 //  runner := sarah.NewRunner(sarah.NewConfig(), runnerOptions.Arg())
 //  runner.Run(context.TODO())
 type Adapter struct {
-	config       *Config
-	client       SlackClient
-	messageQueue chan *textMessage
+	config         *Config
+	client         SlackClient
+	messageQueue   chan *textMessage
+	payloadHandler func(context.Context, *Config, rtmapi.DecodedPayload, func(sarah.Input) error)
 }
 
 // NewAdapter creates new Adapter with given *Config and zero or more AdapterOption.
 func NewAdapter(config *Config, options ...AdapterOption) (*Adapter, error) {
 	adapter := &Adapter{
-		config:       config,
-		messageQueue: make(chan *textMessage, config.SendingQueueSize),
+		config:         config,
+		messageQueue:   make(chan *textMessage, config.SendingQueueSize),
+		payloadHandler: handlePayload, // may be replaced with WithPayloadHandler option.
 	}
 
 	for _, opt := range options {
@@ -183,6 +238,7 @@ func (adapter *Adapter) receivePayload(connCtx context.Context, payloadReceiver 
 		case <-connCtx.Done():
 			log.Info("stop receiving payload due to context cancel")
 			return
+
 		default:
 			payload, err := payloadReceiver.Receive()
 			// TODO should io.EOF and io.ErrUnexpectedEOF treated differently than other errors?
@@ -199,36 +255,43 @@ func (adapter *Adapter) receivePayload(connCtx context.Context, payloadReceiver 
 				continue
 			}
 
-			switch p := payload.(type) {
-			case *rtmapi.WebSocketReply:
-				if !p.OK {
-					log.Errorf("something was wrong with previous message sending. id: %d. text: %s.", p.ReplyTo, p.Text)
-				}
-			case *rtmapi.Message:
-				// Convert RTM specific message to one that satisfies sarah.Input interface.
-				input := &MessageInput{event: p}
-
-				trimmed := strings.TrimSpace(input.Message())
-				if adapter.config.HelpCommand != "" && trimmed == adapter.config.HelpCommand {
-					// Help command
-					help := sarah.NewHelpInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
-					enqueueInput(help)
-				} else if adapter.config.AbortCommand != "" && trimmed == adapter.config.AbortCommand {
-					// Abort command
-					abort := sarah.NewAbortInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
-					enqueueInput(abort)
-				} else {
-					// Regular input
-					enqueueInput(input)
-				}
-			case *rtmapi.Pong:
+			if payload == nil {
 				continue
-			case nil:
-				continue
-			default:
-				log.Debugf("payload given, but no corresponding action is defined. %#v", p)
 			}
+
+			adapter.payloadHandler(connCtx, adapter.config, payload, enqueueInput)
 		}
+	}
+}
+
+func handlePayload(_ context.Context, config *Config, payload rtmapi.DecodedPayload, enqueueInput func(sarah.Input) error) {
+	switch p := payload.(type) {
+	case *rtmapi.WebSocketReply:
+		if !p.OK {
+			log.Errorf("something was wrong with previous message sending. id: %d. text: %s.", p.ReplyTo, p.Text)
+		}
+
+	case *rtmapi.Message:
+		// Convert RTM specific message to one that satisfies sarah.Input interface.
+		input := &MessageInput{event: p}
+
+		trimmed := strings.TrimSpace(input.Message())
+		if config.HelpCommand != "" && trimmed == config.HelpCommand {
+			// Help command
+			help := sarah.NewHelpInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
+			enqueueInput(help)
+		} else if config.AbortCommand != "" && trimmed == config.AbortCommand {
+			// Abort command
+			abort := sarah.NewAbortInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
+			enqueueInput(abort)
+		} else {
+			// Regular input
+			enqueueInput(input)
+		}
+
+	default:
+		log.Debugf("payload given, but no corresponding action is defined. %#v", p)
+
 	}
 }
 


### PR DESCRIPTION
Slack's RTM API provides relatively large variety of event types.
To cover desired events and have customized experience, let developer set desired callback function via functional option on initialization.