### PR TITLE
Avoid race condition on Command/ScheduledTask re-build

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -107,7 +107,7 @@ func TestDefaultBot_AppendCommand(t *testing.T) {
 	myBot.AppendCommand(command)
 
 	registeredCommands := myBot.commands
-	if len(*registeredCommands) != 1 {
+	if len(registeredCommands.collection) != 1 {
 		t.Errorf("1 registered command should exists: %#v.", registeredCommands)
 	}
 }
@@ -136,8 +136,8 @@ func TestDefaultBot_Respond_StorageAcquisitionError(t *testing.T) {
 
 func TestDefaultBot_Respond_WithCommandError(t *testing.T) {
 	expectedErr := errors.New("expected")
-	myBot := &defaultBot{
-		commands: &Commands{
+	commands := &Commands{
+		collection: []Command{
 			&DummyCommand{
 				MatchFunc: func(_ Input) bool {
 					return true
@@ -147,6 +147,9 @@ func TestDefaultBot_Respond_WithCommandError(t *testing.T) {
 				},
 			},
 		},
+	}
+	myBot := &defaultBot{
+		commands: commands,
 	}
 
 	err := myBot.Respond(context.TODO(), &DummyInput{})
@@ -213,7 +216,7 @@ func TestDefaultBot_Respond_WithContextButMessage(t *testing.T) {
 	isSent := false
 	myBot := &defaultBot{
 		userContextStorage: dummyStorage,
-		commands:           &Commands{command},
+		commands:           &Commands{collection: []Command{command}},
 		sendMessageFunc: func(_ context.Context, output Output) {
 			isSent = true
 		},
@@ -330,7 +333,7 @@ func TestDefaultBot_Respond_WithContextStorageSetError(t *testing.T) {
 			sendMessageCalled = true
 		},
 		userContextStorage: dummyStorage,
-		commands:           &Commands{cmd},
+		commands:           &Commands{collection: []Command{cmd}},
 	}
 
 	err := myBot.Respond(context.TODO(), &DummyInput{})
@@ -372,7 +375,7 @@ func TestDefaultBot_Respond_UserContextWithoutStorage(t *testing.T) {
 		sendMessageFunc: func(_ context.Context, output Output) {
 			sendMessageCalled = true
 		},
-		commands:           &Commands{cmd},
+		commands:           &Commands{collection: []Command{cmd}},
 		userContextStorage: nil,
 	}
 
@@ -433,7 +436,7 @@ func TestDefaultBot_Respond_Help(t *testing.T) {
 	}
 	myBot := &defaultBot{
 		userContextStorage: dummyStorage,
-		commands:           &Commands{cmd},
+		commands:           &Commands{collection: []Command{cmd}},
 		sendMessageFunc: func(_ context.Context, output Output) {
 			givenOutput = output
 		},

--- a/command_test.go
+++ b/command_test.go
@@ -300,7 +300,7 @@ func TestCommands_FindFirstMatched(t *testing.T) {
 	irrelevantCommand2.MatchFunc = func(_ Input) bool {
 		return false
 	}
-	commands = &Commands{irrelevantCommand, echoCommand, irrelevantCommand2}
+	commands = &Commands{collection: []Command{irrelevantCommand, echoCommand, irrelevantCommand2}}
 
 	matchedCommand = commands.FindFirstMatched(&DummyInput{MessageValue: "echo"})
 	if matchedCommand == nil {
@@ -332,7 +332,7 @@ func TestCommands_ExecuteFirstMatched(t *testing.T) {
 	echoCommand.ExecuteFunc = func(_ context.Context, _ Input) (*CommandResponse, error) {
 		return &CommandResponse{Content: ""}, nil
 	}
-	commands = &Commands{echoCommand}
+	commands = &Commands{collection: []Command{echoCommand}}
 	response, err = commands.ExecuteFirstMatched(context.TODO(), input)
 	if err != nil {
 		t.Errorf("Unexpected error on command execution: %#v.", err)
@@ -361,18 +361,18 @@ func TestCommands_Append(t *testing.T) {
 
 	// First operation
 	commands.Append(command)
-	if len(*commands) == 0 {
+	if len(commands.collection) == 0 {
 		t.Fatal("Provided command was not appended.")
 	}
 
-	if (*commands)[0] != command {
-		t.Fatalf("Appended command is not the one provided: %#v", (*commands)[0])
+	if (commands.collection)[0] != command {
+		t.Fatalf("Appended command is not the one provided: %#v", commands.collection[0])
 	}
 
 	// Second operation with same command
 	commands.Append(command)
-	if len(*commands) != 1 {
-		t.Fatalf("Expected only one command to stay, but was: %d.", len(*commands))
+	if len(commands.collection) != 1 {
+		t.Fatalf("Expected only one command to stay, but was: %d.", len(commands.collection))
 	}
 
 	// Third operation with different command
@@ -380,8 +380,8 @@ func TestCommands_Append(t *testing.T) {
 		IdentifierValue: "second",
 	}
 	commands.Append(anotherCommand)
-	if len(*commands) != 2 {
-		t.Fatalf("Expected 2 commands to stay, but was: %d.", len(*commands))
+	if len(commands.collection) != 2 {
+		t.Fatalf("Expected 2 commands to stay, but was: %d.", len(commands.collection))
 	}
 }
 
@@ -392,7 +392,7 @@ func TestCommands_Helps(t *testing.T) {
 			return "example"
 		},
 	}
-	commands := &Commands{cmd}
+	commands := &Commands{collection: []Command{cmd}}
 
 	helps := commands.Helps()
 	if len(*helps) != 1 {

--- a/locker.go
+++ b/locker.go
@@ -1,0 +1,32 @@
+package sarah
+
+import "sync"
+
+var configLocker = &configRWLocker{
+	fileMutex: map[string]*sync.RWMutex{},
+	mutex:     sync.Mutex{},
+}
+
+// configRWLocker provides locking mechanism for Command/ScheduledTask to safely read and write config struct.
+// This was introduced to solve race condition caused by concurrent live re-configuration and Command/ScheduledTask execution.
+// Detailed description can be found at https://github.com/oklahomer/go-sarah/issues/44.
+//
+// Mutex instance is created and managed per file path
+// because ScheduledTask and Command may share same Identifier and hence may refer to same configuration file.
+type configRWLocker struct {
+	fileMutex map[string]*sync.RWMutex
+	mutex     sync.Mutex
+}
+
+func (cl *configRWLocker) get(configPath string) *sync.RWMutex {
+	cl.mutex.Lock()
+	defer cl.mutex.Unlock()
+
+	locker, ok := cl.fileMutex[configPath]
+	if !ok {
+		locker = &sync.RWMutex{}
+		cl.fileMutex[configPath] = locker
+	}
+
+	return locker
+}

--- a/runner.go
+++ b/runner.go
@@ -335,10 +335,6 @@ func runBot(ctx context.Context, bot Bot, receiveInput func(Input) error, errNot
 	bot.Run(ctx, receiveInput, errNotifier)
 }
 
-func registerCommand(bot Bot, command Command) {
-	bot.AppendCommand(command)
-}
-
 func registerScheduledTask(botCtx context.Context, bot Bot, task ScheduledTask, taskScheduler scheduler) {
 	err := taskScheduler.update(bot.BotType(), task, func() {
 		executeScheduledTask(botCtx, bot, task)
@@ -356,7 +352,7 @@ func registerCommands(bot Bot, props []*CommandProps, configDir string) {
 			continue
 		}
 
-		registerCommand(bot, command)
+		bot.AppendCommand(command)
 	}
 }
 
@@ -397,7 +393,7 @@ func commandUpdaterFunc(bot Bot, props []*CommandProps) func(string) {
 				return
 			}
 
-			registerCommand(bot, command) // replaces the old one.
+			bot.AppendCommand(command) // replaces the old one.
 			return
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -111,7 +111,7 @@ func newScheduledTask(props *ScheduledTaskProps, configDir string) (ScheduledTas
 		configPath := path.Join(configDir, fileName)
 
 		// https://github.com/oklahomer/go-sarah/issues/44
-		locker := cl.get(configPath)
+		locker := configLocker.get(configPath)
 
 		err := func() error {
 			locker.Lock()

--- a/task.go
+++ b/task.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/context"
 	"os"
 	"path"
+	"sync"
 )
 
 var (
@@ -50,12 +51,18 @@ type ScheduledTask interface {
 	Schedule() string
 }
 
+type taskConfigWrapper struct {
+	value TaskConfig
+	mutex *sync.RWMutex
+}
+
 type scheduledTask struct {
 	identifier         string
 	taskFunc           taskFunc
 	schedule           string
 	defaultDestination OutputDestination
 	config             TaskConfig
+	configWrapper      *taskConfigWrapper
 }
 
 // Identifier returns unique ID of this task.
@@ -71,7 +78,16 @@ func (task *scheduledTask) Identifier() string {
 // When sending messages to multiple destinations, create and return results as many as destinations.
 // If output destination is nil, caller tries to find corresponding destination from config struct.
 func (task *scheduledTask) Execute(ctx context.Context) ([]*ScheduledTaskResult, error) {
-	return task.taskFunc(ctx, task.config)
+	wrapper := task.configWrapper
+	if wrapper == nil {
+		return task.taskFunc(ctx)
+	}
+
+	// If the ScheduledTask has configuration struct, lock before execution.
+	// Config struct may be updated on configuration file change.
+	wrapper.mutex.RLock()
+	defer wrapper.mutex.RUnlock()
+	return task.taskFunc(ctx, wrapper.value)
 }
 
 // Schedule returns execution schedule.
@@ -89,10 +105,20 @@ func newScheduledTask(props *ScheduledTaskProps, configDir string) (ScheduledTas
 	// If path to the configuration files' directory is given, corresponding configuration file MAY exist.
 	// If exists, read and map to given config struct; if file does not exist, assume the config struct is already configured by developer.
 	taskConfig := props.config
+	var configWrapper *taskConfigWrapper
 	if configDir != "" && taskConfig != nil {
 		fileName := props.identifier + ".yaml"
 		configPath := path.Join(configDir, fileName)
-		err := readConfig(configPath, taskConfig)
+
+		// https://github.com/oklahomer/go-sarah/issues/44
+		locker := cl.get(configPath)
+
+		err := func() error {
+			locker.Lock()
+			defer locker.Unlock()
+
+			return readConfig(configPath, taskConfig)
+		}()
 		if err != nil && os.IsNotExist(err) {
 			log.Infof("config struct is set, but there was no corresponding setting file at %s. "+
 				"assume config struct is already filled with appropriate value and keep going. command ID: %s.",
@@ -100,6 +126,11 @@ func newScheduledTask(props *ScheduledTaskProps, configDir string) (ScheduledTas
 		} else if err != nil {
 			// File was there, but could not read.
 			return nil, err
+		}
+
+		configWrapper = &taskConfigWrapper{
+			value: taskConfig,
+			mutex: locker,
 		}
 	}
 
@@ -133,6 +164,7 @@ func newScheduledTask(props *ScheduledTaskProps, configDir string) (ScheduledTas
 		schedule:           schedule,
 		defaultDestination: dest,
 		config:             props.config,
+		configWrapper:      configWrapper,
 	}, nil
 }
 


### PR DESCRIPTION
#44 

With this approach, a lock is provided per file path.
When ```dirwatcher``` detects file change event and there is more than one ```CommandProps``` and/or ```ScheduledTaskProps``` that references the file, corresponding lock is acquired. This locks while ```Command``` or ```ScheduledTask```'s re-build is in progress. ```Command``` or ```ScheduledTask``` tries to run no matter if re-build is in progress, but it blocks until corresponding config struct is updated and re-build is done. Since lock is provided for each configuration file, other ```Command```s and ```ScheduledTask```s continue to run.