### PR TITLE
Handle various config format for live update

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ var CustomizedProps = sarah.NewCommandPropsBuilder().
         MustBuild()
 
 // Configurable is a helper function that returns CommandProps built with given CommandConfig.
-// CommandConfig can be first configured manually or from YAML file, and then fed to this function.
+// CommandConfig can be first configured manually or from YAML/JSON file, and then fed to this function.
 // Returned CommandProps can be fed to Runner and when configuration file is updated,
 // Runner detects the change and re-build the Command with updated configuration struct.
 func Configurable(config sarah.CommandConfig) *sarah.CommandProps {
@@ -135,7 +135,7 @@ This configuration struct is passed on command execution as 3rd argument.
 
 To let Runner supervise file change event, set sarah.Config.PluginConfigRoot.
 Internal directory watcher supervises ```sarah.Config.PluginConfigRoot + "/" + BotType + "/"``` as ```Bot```'s configuration directory.
-When any file under that directory is updated, ```Runner``` searches for corresponding ```CommandProps``` based on the assumption that the file name is equivalent to ```CommandProps.identifier + ".yaml""```.
+When any file under that directory is updated, ```Runner``` searches for corresponding ```CommandProps``` based on the assumption that the file name is equivalent to ```CommandProps.identifier + ".(yaml|yml|json)""```.
 If a corresponding ```CommandProps``` exists, ```Runner``` rebuild ```Command``` with latest configuration values and replaces with the old one.
 
 ## Scheduled Task
@@ -183,7 +183,7 @@ This configuration struct is passed on task execution as 2nd argument.
 
 To let Runner supervise file change event, set sarah.Config.PluginConfigRoot.
 Internal directory watcher supervises ```sarah.Config.PluginConfigRoot + "/" + BotType + "/"``` as ```Bot```'s configuration directory.
-When any file under that directory is updated, ```Runner``` searches for corresponding ```ScheduledTaskProps``` based on the assumption that the file name is equivalent to ```ScheduledTaskProps.identifier + ".yaml""```.
+When any file under that directory is updated, ```Runner``` searches for corresponding ```ScheduledTaskProps``` based on the assumption that the file name is equivalent to ```ScheduledTaskProps.identifier + ".(yaml|yml|json)""```.
 If a corresponding ```ScheduledTaskProps``` exists, ```Runner``` rebuild ```ScheduledTask``` with latest configuration values and replaces with the old one.
 
 ## Alerter

--- a/command.go
+++ b/command.go
@@ -327,8 +327,8 @@ func (builder *CommandPropsBuilder) Func(fn func(context.Context, Input) (*Comma
 
 // ConfigurableFunc is a setter to provide command function.
 // While Func let developers set simple function, this allows them to provide function that requires some sort of configuration struct.
-// On Runner.Run configuration is read from YAML file located at /path/to/config/dir/{commandIdentifier}.yaml and mapped to given CommandConfig struct.
-// If no YAML file is found, Runner considers the given CommandConfig is fully configured and ready to use.
+// On Runner.Run configuration is read from YAML/JSON file located at /path/to/config/dir/{commandIdentifier}.(yaml|yml|json) and mapped to given CommandConfig struct.
+// If no YAML/JSON file is found, Runner considers the given CommandConfig is fully configured and ready to use.
 // This configuration struct is passed to command function as its third argument.
 func (builder *CommandPropsBuilder) ConfigurableFunc(config CommandConfig, fn func(context.Context, Input, CommandConfig) (*CommandResponse, error)) *CommandPropsBuilder {
 	builder.props.config = config

--- a/command_test.go
+++ b/command_test.go
@@ -220,14 +220,159 @@ func Test_buildCommand(t *testing.T) {
 		identifier: "dummy",
 		config:     config,
 	}
+	file := &pluginConfigFile{
+		id:       props.identifier,
+		path:     filepath.Join("testdata", "command", "dummy.yaml"),
+		fileType: yaml_file,
+	}
 
-	_, err := buildCommand(props, filepath.Join("testdata", "command"))
+	_, err := buildCommand(props, file)
 
 	if err != nil {
 		t.Fatalf("Unexpected error is returned: %s.", err.Error())
 	}
 	if config.Token != "foobar" {
 		t.Error("Configuration is not read from testdata/commandbuilder/dummy.yaml file.")
+	}
+}
+
+func Test_buildCommand_WithOutConfig(t *testing.T) {
+	props := &CommandProps{
+		botType:    "foo",
+		identifier: "bar",
+		commandFunc: func(_ context.Context, _ Input, config ...CommandConfig) (*CommandResponse, error) {
+			return nil, nil
+		},
+		matchFunc: func(_ Input) bool {
+			return false
+		},
+		example: ".foo",
+		config:  nil,
+	}
+
+	cmd, err := buildCommand(props, nil)
+
+	if err != nil {
+		t.Fatalf("Unexpected error is returned: %s.", err.Error())
+	}
+
+	if cmd == nil {
+		t.Error("Expected Command is not returned.")
+	}
+}
+
+func Test_buildCommand_WithOutConfigFile(t *testing.T) {
+	props := &CommandProps{
+		botType:    "foo",
+		identifier: "bar",
+		commandFunc: func(_ context.Context, _ Input, config ...CommandConfig) (*CommandResponse, error) {
+			return nil, nil
+		},
+		matchFunc: func(_ Input) bool {
+			return false
+		},
+		example: ".foo",
+		config:  struct{}{}, // non-nil
+	}
+
+	cmd, err := buildCommand(props, nil)
+
+	if err != nil {
+		t.Fatalf("Unexpected error is returned: %s.", err.Error())
+	}
+
+	if cmd == nil {
+		t.Error("Expected Command is not returned.")
+	}
+}
+
+func Test_buildCommand_WithConfigValue(t *testing.T) {
+	type config struct {
+		Token  string `yaml:"token"`
+		Foo    string `yaml:"foo"`
+		hidden string
+	}
+	// *NOT* a pointer
+	c := config{
+		Token:  "default",
+		Foo:    "initial value",
+		hidden: "hashhash",
+	}
+	props := &CommandProps{
+		identifier: "dummy",
+		config:     c,
+	}
+	file := &pluginConfigFile{
+		id:       props.identifier,
+		path:     filepath.Join("testdata", "command", "dummy.yaml"),
+		fileType: yaml_file,
+	}
+
+	cmd, err := buildCommand(props, file)
+
+	if err != nil {
+		t.Fatalf("Unexpected error is returned: %s.", err.Error())
+	}
+	if cmd.(*defaultCommand).configWrapper.value.(config).Token != "foobar" {
+		t.Errorf("Configuration is not read from testdata/commandbuilder/dummy.yaml file. %#v", cmd.(*defaultCommand).configWrapper.value)
+	}
+	if cmd.(*defaultCommand).configWrapper.value.(config).Foo != "initial value" {
+		t.Errorf("Value is lost. %#v", cmd.(*defaultCommand).configWrapper.value)
+	}
+}
+
+func Test_buildCommand_WithConfigMap(t *testing.T) {
+	config := map[string]interface{}{
+		"token": "default",
+		"foo":   "initial value",
+	}
+	props := &CommandProps{
+		identifier: "dummy",
+		config:     config,
+	}
+	file := &pluginConfigFile{
+		id:       props.identifier,
+		path:     filepath.Join("testdata", "command", "dummy.yaml"),
+		fileType: yaml_file,
+	}
+
+	cmd, err := buildCommand(props, file)
+
+	if err != nil {
+		t.Fatalf("Unexpected error is returned: %s.", err.Error())
+	}
+
+	configWrapper := cmd.(*defaultCommand).configWrapper
+	if configWrapper == nil {
+		t.Fatal("CommandConfig is not set.")
+	}
+
+	newConfig, ok := configWrapper.value.(map[string]interface{})
+	fmt.Printf("%#v", newConfig)
+	if !ok {
+		t.Fatalf("CommandConfig type is not valid: %T", configWrapper.value)
+	}
+
+	// Make sure original value is updated.
+	v, ok := config["token"]
+	if ok && v != "foobar" {
+		t.Errorf("Unexpected token value is set: %s", v)
+	} else if !ok {
+		t.Error("Token key does not exist.")
+	}
+
+	v, ok = newConfig["token"]
+	if ok && v != "foobar" {
+		t.Errorf("Unexpected token value is set: %s", v)
+	} else if !ok {
+		t.Error("Token key does not exist.")
+	}
+
+	v, ok = newConfig["foo"]
+	if ok && v != "initial value" {
+		t.Errorf("Unexpected foo value is set: %s", v)
+	} else if !ok {
+		t.Error("Foo key does not exist.")
 	}
 }
 
@@ -241,15 +386,20 @@ func Test_buildCommand_BrokenYaml(t *testing.T) {
 		identifier: "broken",
 		config:     config,
 	}
+	file := &pluginConfigFile{
+		id:       props.identifier,
+		path:     filepath.Join("testdata", "command", "broken.yaml"),
+		fileType: yaml_file,
+	}
 
-	_, err := buildCommand(props, filepath.Join("testdata", "command"))
+	_, err := buildCommand(props, file)
 
 	if err == nil {
 		t.Fatal("Error must be returned.")
 	}
 }
 
-func Test_buildCommand_WithOutConfigFile(t *testing.T) {
+func Test_buildCommand_WithUnlocatableConfigFile(t *testing.T) {
 	config := &struct {
 		Token string
 	}{
@@ -262,15 +412,16 @@ func Test_buildCommand_WithOutConfigFile(t *testing.T) {
 		commandFunc: func(_ context.Context, _ Input, _ ...CommandConfig) (*CommandResponse, error) { return nil, nil },
 		config:      config,
 	}
-
-	command, err := buildCommand(props, filepath.Join("testdata", "command"))
-
-	if err != nil {
-		t.Fatalf("Error should not be returned just because configuration file is not found: %s.", err.Error())
+	file := &pluginConfigFile{
+		id:       props.identifier,
+		path:     filepath.Join("testdata", "command", "fileNotFound.yaml"),
+		fileType: yaml_file,
 	}
 
-	if command == nil {
-		t.Fatal("Built Command is not returned.")
+	_, err := buildCommand(props, file)
+
+	if err == nil {
+		t.Fatalf("Error should be returned when expecting config file is not located: %s.", err.Error())
 	}
 }
 
@@ -507,6 +658,12 @@ func Test_race_commandRebuild(t *testing.T) {
 	rootCtx := context.Background()
 	ctx, cancel := context.WithCancel(rootCtx)
 
+	file := &pluginConfigFile{
+		id:       props.identifier,
+		path:     filepath.Join("testdata", "command", "dummy.yaml"),
+		fileType: yaml_file,
+	}
+
 	// Continuously read configuration file and re-build Command
 	go func(c context.Context, b Bot, p *CommandProps) {
 		for {
@@ -516,7 +673,7 @@ func Test_race_commandRebuild(t *testing.T) {
 
 			default:
 				// Write
-				command, err := buildCommand(p, filepath.Join("testdata", "command"))
+				command, err := buildCommand(p, file)
 				if err == nil {
 					b.AppendCommand(command)
 				} else {

--- a/command_test.go
+++ b/command_test.go
@@ -210,7 +210,7 @@ func TestCommandPropsBuilder_MustBuild(t *testing.T) {
 	}
 }
 
-func Test_newCommand(t *testing.T) {
+func Test_buildCommand(t *testing.T) {
 	config := &struct {
 		Token string `yaml:"token"`
 	}{
@@ -221,7 +221,7 @@ func Test_newCommand(t *testing.T) {
 		config:     config,
 	}
 
-	_, err := newCommand(props, filepath.Join("testdata", "command"))
+	_, err := buildCommand(props, filepath.Join("testdata", "command"))
 
 	if err != nil {
 		t.Fatalf("Unexpected error is returned: %s.", err.Error())
@@ -231,7 +231,7 @@ func Test_newCommand(t *testing.T) {
 	}
 }
 
-func Test_newCommand_BrokenYaml(t *testing.T) {
+func Test_buildCommand_BrokenYaml(t *testing.T) {
 	config := &struct {
 		Token string `yaml:"token"`
 	}{
@@ -242,14 +242,14 @@ func Test_newCommand_BrokenYaml(t *testing.T) {
 		config:     config,
 	}
 
-	_, err := newCommand(props, filepath.Join("testdata", "command"))
+	_, err := buildCommand(props, filepath.Join("testdata", "command"))
 
 	if err == nil {
 		t.Fatal("Error must be returned.")
 	}
 }
 
-func Test_newCommand_WithOutConfigFile(t *testing.T) {
+func Test_buildCommand_WithOutConfigFile(t *testing.T) {
 	config := &struct {
 		Token string
 	}{
@@ -263,7 +263,7 @@ func Test_newCommand_WithOutConfigFile(t *testing.T) {
 		config:      config,
 	}
 
-	command, err := newCommand(props, filepath.Join("testdata", "command"))
+	command, err := buildCommand(props, filepath.Join("testdata", "command"))
 
 	if err != nil {
 		t.Fatalf("Error should not be returned just because configuration file is not found: %s.", err.Error())
@@ -516,7 +516,7 @@ func Test_race_commandRebuild(t *testing.T) {
 
 			default:
 				// Write
-				command, err := newCommand(p, filepath.Join("testdata", "command"))
+				command, err := buildCommand(p, filepath.Join("testdata", "command"))
 				if err == nil {
 					b.AppendCommand(command)
 				} else {

--- a/doc/uml/component.puml
+++ b/doc/uml/component.puml
@@ -115,7 +115,7 @@ component "Runner" as runner {
 
     component "Cron" as cron {
     }
-    note top of cron
+    note bottom of cron
     Execute //ScheduledTask//
     periodically.
     end note
@@ -137,6 +137,10 @@ component "Runner" as runner {
         file alarm.yaml
         file weather.yaml
     }
+    note bottom of configDir
+    Below extensions are supported:
+    .yaml, .yml and .json
+    end note
 }
 note top of runner
 Takes care of other components' life cycles.

--- a/locker.go
+++ b/locker.go
@@ -2,7 +2,6 @@ package sarah
 
 import (
 	"fmt"
-	"path/filepath"
 	"sync"
 )
 
@@ -22,16 +21,11 @@ type configRWLocker struct {
 	mutex     sync.Mutex
 }
 
-func (cl *configRWLocker) get(configDir string, pluginID string) *sync.RWMutex {
+func (cl *configRWLocker) get(botType BotType, pluginID string) *sync.RWMutex {
 	cl.mutex.Lock()
 	defer cl.mutex.Unlock()
 
-	absDir, err := filepath.Abs(configDir)
-	if err != nil {
-		panic(fmt.Sprintf("failed to get absolute path to configuration files: %s", err.Error()))
-	}
-	lockID := fmt.Sprintf("dir:%s::id:%s", absDir, pluginID)
-
+	lockID := fmt.Sprintf("botType:%s::id:%s", botType.String(), pluginID)
 	locker, ok := cl.fileMutex[lockID]
 	if !ok {
 		locker = &sync.RWMutex{}

--- a/plugins/worldweather/weather.go
+++ b/plugins/worldweather/weather.go
@@ -16,7 +16,7 @@ Setup should be somewhat like below:
   options.Append(sarah.WithCommandProps(worldweather.SlackProps))
 
   // Config.PluginConfigRoot must be set to read configuration file for this command.
-  // Runner searches for configuration file located at config.PluginConfigRoot + "/slack/weather.yaml".
+  // Runner searches for configuration file located at config.PluginConfigRoot + "/slack/weather.(yaml|yml|json)".
   config := sarah.NewConfig()
   config.PluginConfigRoot = "/path/to/config/" // Or do yaml.Unmarshal(fileBuf, config), json.Unmarshal(fileBuf, config)
   runner, err := sarah.NewRunner(config, options.Arg())

--- a/runner.go
+++ b/runner.go
@@ -643,20 +643,7 @@ func updatePluginConfig(file *pluginConfigFile, configPtr interface{}) error {
 var (
 	errUnableToDetermineConfigFileFormat = errors.New("can not determine file format")
 	errUnsupportedConfigFileFormat       = errors.New("unsupported file format")
-)
-
-func plainPathToFile(path string) (*pluginConfigFile, error) {
-	path, err := filepath.Abs(path)
-	if err != nil {
-		return nil, err
-	}
-
-	ext := filepath.Ext(path)
-	if ext == "" {
-		return nil, errUnableToDetermineConfigFileFormat
-	}
-
-	candidates := []struct {
+	configFileCandidates                 = []struct {
 		ext      string
 		fileType fileType
 	}{
@@ -673,11 +660,23 @@ func plainPathToFile(path string) (*pluginConfigFile, error) {
 			fileType: json_file,
 		},
 	}
+)
+
+func plainPathToFile(path string) (*pluginConfigFile, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ext := filepath.Ext(path)
+	if ext == "" {
+		return nil, errUnableToDetermineConfigFileFormat
+	}
 
 	_, filename := filepath.Split(path)
 	id := strings.TrimSuffix(filename, ext) // buzz.yaml to buzz
 
-	for _, c := range candidates {
+	for _, c := range configFileCandidates {
 		if ext != c.ext {
 			continue
 		}
@@ -693,25 +692,7 @@ func plainPathToFile(path string) (*pluginConfigFile, error) {
 }
 
 func findPluginConfigFile(configDir, id string) *pluginConfigFile {
-	candidates := []struct {
-		ext      string
-		fileType fileType
-	}{
-		{
-			ext:      ".yaml",
-			fileType: yaml_file,
-		},
-		{
-			ext:      ".yml",
-			fileType: yaml_file,
-		},
-		{
-			ext:      ".json",
-			fileType: json_file,
-		},
-	}
-
-	for _, c := range candidates {
+	for _, c := range configFileCandidates {
 		configPath := filepath.Join(configDir, fmt.Sprintf("%s%s", id, c.ext))
 		_, err := os.Stat(configPath)
 		if err == nil {

--- a/runner.go
+++ b/runner.go
@@ -1,11 +1,16 @@
 package sarah
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/oklahomer/go-sarah/log"
 	"github.com/oklahomer/go-sarah/watchers"
 	"github.com/oklahomer/go-sarah/workers"
 	"golang.org/x/net/context"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -270,26 +275,17 @@ func (runner *Runner) Run(ctx context.Context) {
 		commandProps := runner.botCommandProps(botType)
 		registerCommands(bot, commandProps, configDir)
 
-		// Supervise configuration files' directory for commands.
-		if configDir != "" {
-			callback := commandUpdaterFunc(bot, commandProps)
-			err := runner.watcher.Subscribe(botType.String(), configDir, callback)
-			if err != nil {
-				log.Errorf("failed to watch %s: %s", configDir, err.Error())
-			}
-		}
-
 		// Register scheduled tasks.
 		tasks := runner.botScheduledTasks(botType)
 		taskProps := runner.botScheduledTaskProps(botType)
 		registerScheduledTasks(botCtx, bot, tasks, taskProps, taskScheduler, configDir)
 
-		// Supervise configuration files' directory for scheduled tasks.
+		// Supervise configuration files' directory for Command/ScheduledTask.
 		if configDir != "" {
-			callback := scheduledTaskUpdaterFunc(botCtx, bot, taskProps, taskScheduler)
+			callback := runner.configUpdateCallback(botCtx, bot, taskScheduler)
 			err := runner.watcher.Subscribe(botType.String(), configDir, callback)
 			if err != nil {
-				log.Errorf("failed to watch %s: %s", configDir, err.Error())
+				log.Errorf("Failed to watch %s: %s", configDir, err.Error())
 			}
 		}
 
@@ -310,6 +306,34 @@ func (runner *Runner) Run(ctx context.Context) {
 	}
 
 	wg.Wait()
+}
+
+func (runner *Runner) configUpdateCallback(botCtx context.Context, bot Bot, taskScheduler scheduler) func(string) {
+	return func(path string) {
+		file, err := plainPathToFile(path)
+		if err == errUnableToDetermineConfigFileFormat {
+			log.Warnf("File under Config.PluginConfigRoot is updated, but file format can not be determined from its extension: %s.", path)
+			return
+		} else if err == errUnableToDetermineConfigFileFormat {
+			log.Warnf("File under Config.PluginConfigRoot is updated, but file format is not supported: %s.", path)
+			return
+		} else if err != nil {
+			log.Warnf("Failed to locate %s: %s", path, err.Error())
+			return
+		}
+
+		go func() {
+			commandProps := runner.botCommandProps(bot.BotType())
+			if e := updateCommandConfig(commandProps, file); e != nil {
+				log.Errorf("Failed to update Command config: %s.", err.Error())
+			}
+
+			taskProps := runner.botScheduledTaskProps(bot.BotType())
+			if e := updateScheduledTaskConfig(botCtx, bot, taskProps, taskScheduler, file); e != nil {
+				log.Errorf("Failed to update ScheduledTask config: %s", err.Error())
+			}
+		}()
+	}
 }
 
 func runBot(ctx context.Context, bot Bot, receiveInput func(Input) error, errNotifier func(error)) {
@@ -346,7 +370,7 @@ func registerScheduledTask(botCtx context.Context, bot Bot, task ScheduledTask, 
 
 func registerCommands(bot Bot, props []*CommandProps, configDir string) {
 	for _, props := range props {
-		command, err := newCommand(props, configDir)
+		command, err := buildCommand(props, configDir)
 		if err != nil {
 			log.Errorf("can't configure command. %s. %#v", err.Error(), props)
 			continue
@@ -358,7 +382,7 @@ func registerCommands(bot Bot, props []*CommandProps, configDir string) {
 
 func registerScheduledTasks(botCtx context.Context, bot Bot, tasks []ScheduledTask, props []*ScheduledTaskProps, taskScheduler scheduler, configDir string) {
 	for _, props := range props {
-		task, err := newScheduledTask(props, configDir)
+		task, err := buildScheduledTask(props, configDir)
 		if err != nil {
 			log.Errorf("can't configure scheduled task: %s. %#v.", err.Error(), props)
 			continue
@@ -377,49 +401,67 @@ func registerScheduledTasks(botCtx context.Context, bot Bot, tasks []ScheduledTa
 	}
 }
 
-func commandUpdaterFunc(bot Bot, props []*CommandProps) func(string) {
-	return func(path string) {
-		dir, filename := filepath.Split(path)
-		id := strings.TrimSuffix(filename, filepath.Ext(filename)) // buzz.yaml to buzz
+func updateCommandConfig(props []*CommandProps, file *pluginConfigFile) error {
+	dir, _ := filepath.Split(file.path)
 
-		for _, p := range props {
-			if p.identifier != id {
-				continue
-			}
-			log.Infof("start rebuilding command due to config file change: %s.", id)
-			command, err := newCommand(p, dir)
-			if err != nil {
-				log.Errorf("can't configure command. id: %s. %s", p.identifier, err.Error())
-				return
-			}
-
-			bot.AppendCommand(command) // replaces the old one.
-			return
+	for _, p := range props {
+		if p.config == nil {
+			continue
 		}
+
+		if p.identifier != file.id {
+			continue
+		}
+
+		log.Infof("Start updating config due to config file change: %s.", file.id)
+
+		err := func() error {
+			// https://github.com/oklahomer/go-sarah/issues/44
+			locker := configLocker.get(dir, p.identifier)
+			locker.Lock()
+			defer locker.Unlock()
+
+			return updatePluginConfig(file, p.config)
+		}()
+
+		if err != nil {
+			return fmt.Errorf("failed to update config for %s: %s", p.identifier, err.Error())
+		}
+
+		log.Infof("End updating config due to config file change: %s.", file.id)
+
+		return nil
 	}
+
+	return nil
 }
 
-func scheduledTaskUpdaterFunc(botCtx context.Context, bot Bot, taskProps []*ScheduledTaskProps, taskScheduler scheduler) func(string) {
-	return func(path string) {
-		dir, filename := filepath.Split(path)
-		id := strings.TrimSuffix(filename, filepath.Ext(filename)) // buzz.yaml to buzz
+func updateScheduledTaskConfig(botCtx context.Context, bot Bot, taskProps []*ScheduledTaskProps, taskScheduler scheduler, file *pluginConfigFile) error {
+	dir, _ := filepath.Split(file.path)
 
-		for _, p := range taskProps {
-			if p.identifier != id {
-				continue
-			}
-
-			log.Infof("start rebuilding scheduled task due to config file change: %s.", id)
-			task, err := newScheduledTask(p, dir)
-			if err != nil {
-				log.Errorf("can't configure scheduled task. id: %s. %s", p.identifier, err.Error())
-				return
-			}
-
-			registerScheduledTask(botCtx, bot, task, taskScheduler)
-			return
+	for _, p := range taskProps {
+		if p.config == nil {
+			continue
 		}
+
+		if p.identifier != file.id {
+			continue
+		}
+
+		log.Infof("Start rebuilding scheduled task due to config file change: %s.", file.id)
+		task, err := buildScheduledTask(p, dir)
+		if err != nil {
+			return fmt.Errorf("failed to re-build scheduled task id: %s error: %s", p.identifier, err.Error())
+		}
+
+		registerScheduledTask(botCtx, bot, task, taskScheduler)
+
+		log.Infof("End rebuilding scheduled task due to config file change: %s.", file.id)
+
+		return nil
 	}
+
+	return nil
 }
 
 func executeScheduledTask(ctx context.Context, bot Bot, task ScheduledTask) {
@@ -533,4 +575,130 @@ func setupInputReceiver(botCtx context.Context, bot Bot, worker workers.Worker) 
 		// Could not send because probably the workers are too busy or the runner context is already canceled.
 		return NewBlockedInputError(continuousEnqueueErrCnt)
 	}
+}
+
+type fileType uint
+
+const (
+	_ fileType = iota
+	yaml_file
+	json_file
+)
+
+type pluginConfigFile struct {
+	id       string
+	path     string
+	fileType fileType
+}
+
+func updatePluginConfig(file *pluginConfigFile, configPtr interface{}) error {
+	buf, err := ioutil.ReadFile(file.path)
+	if err != nil {
+		return err
+	}
+
+	switch file.fileType {
+	case yaml_file:
+		return yaml.Unmarshal(buf, configPtr)
+
+	case json_file:
+		return json.Unmarshal(buf, configPtr)
+
+	default:
+		return fmt.Errorf("Unsupported file type: %s.", file.path)
+
+	}
+}
+
+var (
+	errUnableToDetermineConfigFileFormat = errors.New("can not determine file format")
+	errUnsupportedConfigFileFormat       = errors.New("unsupported file format")
+	errFailedToLocateConfigFile          = errors.New("failed to locate file")
+)
+
+func plainPathToFile(path string) (*pluginConfigFile, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ext := filepath.Ext(path)
+	if ext == "" {
+		return nil, errUnableToDetermineConfigFileFormat
+	}
+
+	candidates := []struct {
+		ext      string
+		fileType fileType
+	}{
+		{
+			ext:      ".yaml",
+			fileType: yaml_file,
+		},
+		{
+			ext:      ".yml",
+			fileType: yaml_file,
+		},
+		{
+			ext:      ".json",
+			fileType: json_file,
+		},
+	}
+
+	_, filename := filepath.Split(path)
+	id := strings.TrimSuffix(filename, ext) // buzz.yaml to buzz
+
+	for _, c := range candidates {
+		if ext != c.ext {
+			continue
+		}
+
+		return &pluginConfigFile{
+			id:       id,
+			path:     path,
+			fileType: c.fileType,
+		}, nil
+	}
+
+	return nil, errUnsupportedConfigFileFormat
+}
+
+func findPluginConfigFile(configDir, id string) *pluginConfigFile {
+	candidates := []struct {
+		ext      string
+		fileType fileType
+	}{
+		{
+			ext:      ".yaml",
+			fileType: yaml_file,
+		},
+		{
+			ext:      ".yml",
+			fileType: yaml_file,
+		},
+		{
+			ext:      ".json",
+			fileType: json_file,
+		},
+	}
+
+	for _, c := range candidates {
+		configPath, err := filepath.Abs(filepath.Join(configDir, fmt.Sprintf("%s%s", id, c.ext)))
+		if err != nil {
+			// TODO proper error handling by caller.
+			return nil
+		}
+
+		_, err = os.Stat(configPath)
+		if err == nil {
+			// File exists.
+			return &pluginConfigFile{
+				id:       id,
+				path:     configPath,
+				fileType: c.fileType,
+			}
+		}
+	}
+
+	return nil
 }

--- a/task.go
+++ b/task.go
@@ -3,9 +3,9 @@ package sarah
 import (
 	"errors"
 	"fmt"
-	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
 	"os"
+	"reflect"
 	"sync"
 )
 
@@ -100,36 +100,62 @@ func (task *scheduledTask) DefaultDestination() OutputDestination {
 	return task.defaultDestination
 }
 
-func buildScheduledTask(props *ScheduledTaskProps, configDir string) (ScheduledTask, error) {
-	// If path to the configuration files' directory is given, corresponding configuration file MAY exist.
-	// If exists, read and map to given config struct; if file does not exist, assume the config struct is already configured by developer.
-	taskConfig := props.config
-	var configWrapper *taskConfigWrapper
-	if configDir != "" && taskConfig != nil {
-		file := findPluginConfigFile(configDir, props.identifier)
-
-		// https://github.com/oklahomer/go-sarah/issues/44
-		locker := configLocker.get(configDir, props.identifier)
-		if file != nil {
-			err := func() error {
-				locker.Lock()
-				defer locker.Unlock()
-
-				return updatePluginConfig(file, taskConfig)
-			}()
-			if err != nil && os.IsNotExist(err) {
-				log.Infof("config struct is set, but there was no corresponding setting file at %s. "+
-					"assume config struct is already filled with appropriate value and keep going. command ID: %s.",
-					configDir, props.identifier)
-			} else if err != nil {
-				// File was there, but could not read.
-				return nil, err
-			}
+func buildScheduledTask(props *ScheduledTaskProps, file *pluginConfigFile) (ScheduledTask, error) {
+	if props.config == nil {
+		// If config struct is not set, props MUST provide settings to set schedule.
+		if props.schedule == "" {
+			return nil, ErrTaskScheduleNotGiven
 		}
 
-		configWrapper = &taskConfigWrapper{
-			value: taskConfig,
-			mutex: locker,
+		dest := props.defaultDestination // Can be nil because task response may return specific destination to send result to.
+		return &scheduledTask{
+			identifier:         props.identifier,
+			taskFunc:           props.taskFunc,
+			schedule:           props.schedule,
+			defaultDestination: dest,
+			config:             props.config,
+			configWrapper:      nil,
+		}, nil
+	}
+
+	// https://github.com/oklahomer/go-sarah/issues/44
+	//
+	// Because config file can be created later and that may trigger config struct's live update,
+	// locker needs to be obtained and passed to ScheduledTask to avoid concurrent read/write.
+	// Until then, assume given TaskConfig is already configured and proceed to build.
+	locker := configLocker.get(props.botType, props.identifier)
+	taskConfig := props.config
+	if file != nil {
+		// Minimize the scope of mutex with anonymous function for better performance.
+		err := func() error {
+			locker.Lock()
+			defer locker.Unlock()
+
+			rv := reflect.ValueOf(taskConfig)
+			if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Map {
+				return updatePluginConfig(file, taskConfig)
+			} else {
+				// https://groups.google.com/forum/#!topic/Golang-Nuts/KB3_Yj3Ny4c
+				// Obtain a pointer to the *underlying type* instead of not sarah.CommandConfig.
+				n := reflect.New(reflect.TypeOf(taskConfig))
+
+				// Copy the current value to newly created instance.
+				// This includes private field values.
+				n.Elem().Set(rv)
+
+				// Pass the pointer to the newly created instance.
+				e := updatePluginConfig(file, n.Interface())
+
+				// Replace the current value with updated value.
+				taskConfig = n.Elem().Interface()
+				return e
+			}
+		}()
+		if err != nil && os.IsNotExist(err) {
+			return nil, fmt.Errorf("Config file property was given, but failed to locate it: %s", err.Error())
+		} else if err != nil {
+			// File was there, but could not read.
+			return nil, err
 		}
 	}
 
@@ -163,7 +189,10 @@ func buildScheduledTask(props *ScheduledTaskProps, configDir string) (ScheduledT
 		schedule:           schedule,
 		defaultDestination: dest,
 		config:             props.config,
-		configWrapper:      configWrapper,
+		configWrapper: &taskConfigWrapper{
+			value: taskConfig,
+			mutex: locker,
+		},
 	}, nil
 }
 

--- a/task_test.go
+++ b/task_test.go
@@ -275,7 +275,7 @@ func TestScheduledTask_Schedule(t *testing.T) {
 	}
 }
 
-func Test_newScheduledTask_WithOutConfigFile(t *testing.T) {
+func Test_buildScheduledTask_WithOutConfigFile(t *testing.T) {
 	config := &struct {
 		Token string
 	}{
@@ -291,7 +291,7 @@ func Test_newScheduledTask_WithOutConfigFile(t *testing.T) {
 		config:             config,
 	}
 
-	task, err := newScheduledTask(props, filepath.Join("testdata", "command"))
+	task, err := buildScheduledTask(props, filepath.Join("testdata", "command"))
 
 	if err != nil {
 		t.Fatalf("Error should not be returned just because configuration file is not found: %s.", err.Error())
@@ -302,7 +302,7 @@ func Test_newScheduledTask_WithOutConfigFile(t *testing.T) {
 	}
 }
 
-func Test_newScheduledTask_WithBrokenYaml(t *testing.T) {
+func Test_buildScheduledTask_WithBrokenYaml(t *testing.T) {
 	config := &struct {
 		Token string `yaml:"token"`
 	}{
@@ -317,14 +317,14 @@ func Test_newScheduledTask_WithBrokenYaml(t *testing.T) {
 		config:             config,
 	}
 
-	_, err := newScheduledTask(props, filepath.Join("testdata", "command"))
+	_, err := buildScheduledTask(props, filepath.Join("testdata", "command"))
 
 	if err == nil {
 		t.Fatal("Error must be returned.")
 	}
 }
 
-func Test_newScheduledTask_WithOutSchedule(t *testing.T) {
+func Test_buildScheduledTask_WithOutSchedule(t *testing.T) {
 	emptyScheduleConfig := &DummyScheduledTaskConfig{}
 	emptyScheduleProps := &ScheduledTaskProps{
 		identifier:         "fileNotFound",
@@ -333,7 +333,7 @@ func Test_newScheduledTask_WithOutSchedule(t *testing.T) {
 		config:             emptyScheduleConfig,
 	}
 
-	_, err := newScheduledTask(emptyScheduleProps, filepath.Join("testdata", "command"))
+	_, err := buildScheduledTask(emptyScheduleProps, filepath.Join("testdata", "command"))
 
 	if err == nil {
 		t.Fatal("Epected error is not returned.")
@@ -357,7 +357,7 @@ func Test_newScheduledTask_WithDefaultDestinationConfig(t *testing.T) {
 		config:             config,
 	}
 
-	task, err := newScheduledTask(props, filepath.Join("testdata", "command"))
+	task, err := buildScheduledTask(props, filepath.Join("testdata", "command"))
 
 	if err != nil {
 		t.Fatalf("Unexpected error is returned: %s.", err.Error())
@@ -391,7 +391,7 @@ func Test_race_taskRebuild(t *testing.T) {
 	rootCtx := context.Background()
 	ctx, cancel := context.WithCancel(rootCtx)
 
-	task, err := newScheduledTask(props, filepath.Join("testdata", "command"))
+	task, err := buildScheduledTask(props, filepath.Join("testdata", "command"))
 	if err != nil {
 		t.Fatalf("Error on ScheduledTask build: %s.", err.Error())
 	}
@@ -405,7 +405,7 @@ func Test_race_taskRebuild(t *testing.T) {
 
 			default:
 				// Write
-				_, err := newScheduledTask(p, filepath.Join("testdata", "command"))
+				_, err := buildScheduledTask(p, filepath.Join("testdata", "command"))
 				if err != nil {
 					t.Errorf("Error on command build: %s.", err.Error())
 				}


### PR DESCRIPTION
Live configuration update is a signature feature of this project. However current implementation only allows YAML formatted file with .y**a**ml extension. Add JSON with .json extension to acceptable format and also allow YAML with .yml (with no "a" in the middle) extension.

In the course of this modification, this p-r tries to improve one more live updating logic by re-build ```Command``` only when it is required. Currently [pointer to config struct](https://github.com/oklahomer/go-sarah/blob/master/command.go#L343) is only allowed to be set. At least ```go-sarah``` expects developer to set pointer. If passed ```CommandConfig``` is a pointer to struct, then ```Command``` does not need to be re-built or replaced because updating previously set ```CommandConfig``` also affect the behavior of existing ```Command```; existing ```Command``` refers to the same struct value with the pointer. The only time ```Command``` needs to be re-built is the time that given ```CommandConfig``` is a struct value, but pointer.

For ```ScheduledTask```, always re-build task and re-schedule no matter ```TaskConfig``` is pointer or value. Updating ```TaskConfig``` requires more settings if it implements ```ScheduledConfig``` or ```DestinatedConfig``` so re-building and re-scheduling should be simpler.

So the changes are to:
- Accept .yml and .json as well as .yaml
- If given ```CommandConfig``` is a pointer, simply update the underlying value and do not proceed to re-build.
- If given ```CommandConfig``` is a struct value, re-build.