### PR TITLE
Only expose sarah.Runner interface to avoid unexpected external functional option call

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Bot provides interface for each bot implementation.
-// Instance of concrete type can be fed to Runner.RegisterBot to have its lifecycle managed by Runner.
-// Multiple Bot implementation may be registered to single Runner instance.
+// Instance of concrete type can be fed to Runner.RegisterBot to have its lifecycle under control.
+// Multiple Bot implementation may be registered to single Runner.
 type Bot interface {
 	// BotType represents what this Bot implements. e.g. slack, gitter, cli, etc...
 	// This can be used as a unique ID to distinguish one from another.

--- a/command.go
+++ b/command.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// ErrCommandInsufficientArgument depicts an error that not enough arguments are set to CommandProps.
-	// This is returned on CommandProps.Build() inside of Runner.Run()
+	// This is returned on CommandProps.Build() inside of runner.Run()
 	ErrCommandInsufficientArgument = errors.New("BotType, Identifier, InputExample, MatchFunc, and (Configurable)Func must be set.")
 )
 
@@ -328,7 +328,7 @@ func (builder *CommandPropsBuilder) Func(fn func(context.Context, Input) (*Comma
 // ConfigurableFunc is a setter to provide command function.
 // While Func let developers set simple function, this allows them to provide function that requires some sort of configuration struct.
 // On Runner.Run configuration is read from YAML/JSON file located at /path/to/config/dir/{commandIdentifier}.(yaml|yml|json) and mapped to given CommandConfig struct.
-// If no YAML/JSON file is found, Runner considers the given CommandConfig is fully configured and ready to use.
+// If no YAML/JSON file is found, runner considers the given CommandConfig is fully configured and ready to use.
 // This configuration struct is passed to command function as its third argument.
 func (builder *CommandPropsBuilder) ConfigurableFunc(config CommandConfig, fn func(context.Context, Input, CommandConfig) (*CommandResponse, error)) *CommandPropsBuilder {
 	builder.props.config = config

--- a/examples/main.go
+++ b/examples/main.go
@@ -80,17 +80,17 @@ func main() {
 	// This Command is not subject to config file supervision.
 	slackBot.AppendCommand(echo.Command)
 
-	// Setup Runner.
+	// Setup sarah.Runner.
 	runner, err := sarah.NewRunner(config.Runner, runnerOptions.Arg())
 	if err != nil {
 		panic(fmt.Errorf("Error on Runner construction: %s.", err.Error()))
 	}
 
-	// Run Runner.
+	// Run sarah.Runner.
 	run(runner)
 }
 
-func run(runner *sarah.Runner) {
+func run(runner sarah.Runner) {
 	ctx, cancel := context.WithCancel(context.Background())
 	runnerStop := make(chan struct{})
 	go func() {

--- a/examples/plugins/hello/props.go
+++ b/examples/plugins/hello/props.go
@@ -6,7 +6,7 @@ a function is set via CommandPropsBuilder.MatchFunc to do the equivalent task.
 With CommandPropsBuilder.MatchFunc, developers may define more complex matching logic than assigning simple regular expression to CommandPropsBuilder.MatchPattern.
 One more benefit is that strings package or other packages with higher performance can be used internally like this example.
 
-This sarah.CommandProps can be fed to Runner.New as below.
+This sarah.CommandProps can be fed to sarah.NewRunner() as below.
 
   runner, err := sarah.NewRunner(config.Runner, sarah.WithCommandProps(hello.SlackProps), ... )
 */

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -89,7 +89,7 @@ func WithPayloadHandler(fnc func(context.Context, *Config, rtmapi.DecodedPayload
 
 // Adapter internally calls Slack Rest API and Real Time Messaging API to offer Bot developers easy way to communicate with Slack.
 //
-// This implements sarah.Adapter interface, so this instance can be fed to sarah.Runner instance as below.
+// This implements sarah.Adapter interface, so this instance can be fed to sarah.Runner as below.
 //
 //  runnerOptions := sarah.NewRunnerOptions()
 //
@@ -150,11 +150,11 @@ func (adapter *Adapter) BotType() sarah.BotType {
 // Run establishes connection with Slack, supervise it, and tries to reconnect when current connection is gone.
 // Connection will be
 //
-// When message is sent from slack server, the payload is passed to Runner via the function given as 2nd argument, enqueueInput.
+// When message is sent from slack server, the payload is passed to sarah.Runner via the function given as 2nd argument, enqueueInput.
 // This function simply wraps a channel to prevent blocking situation. When workers are too busy and channel blocks, this function returns BlockedInputError.
 //
-// When critical situation such as reconnection trial fails for specified times, this critical situation is notified to Runner via 3rd argument function, notifyErr.
-// Runner cancels this Bot/Adapter and related resources when BotNonContinuableError is given to this function.
+// When critical situation such as reconnection trial fails for specified times, this critical situation is notified to sarah.Runner via 3rd argument function, notifyErr.
+// sarah.Runner cancels this Bot/Adapter and related resources when BotNonContinuableError is given to this function.
 func (adapter *Adapter) Run(ctx context.Context, enqueueInput func(sarah.Input) error, notifyErr func(error)) {
 	for {
 		conn, err := adapter.connect(ctx)

--- a/task.go
+++ b/task.go
@@ -254,7 +254,7 @@ func (builder *ScheduledTaskPropsBuilder) DefaultDestination(dest OutputDestinat
 // ConfigurableFunc sets function for ScheduledTask with configuration struct.
 // Passed configuration struct is passed to function as a third argument.
 //
-// When resulting ScheduledTaskProps is passed Runner.New as part of sarah.WithScheduledTaskProps and Runner runs with Config.PluginConfigRoot,
+// When resulting ScheduledTaskProps is passed to sarah.NewRunner() as part of sarah.WithScheduledTaskProps and Runner runs with Config.PluginConfigRoot,
 // configuration struct gets updated automatically when corresponding configuration file is updated.
 func (builder *ScheduledTaskPropsBuilder) ConfigurableFunc(config TaskConfig, fn func(context.Context, TaskConfig) ([]*ScheduledTaskResult, error)) *ScheduledTaskPropsBuilder {
 	builder.props.config = config


### PR DESCRIPTION
# Current Implementation
Currently ```sarah.Runner``` struct is directly exposed and its instance is returned on ```sarah.NewRunner()``` call. This is by design. All components other than ```sarah.Runner``` provide interfaces and their default implementations so developers may replace one or more components' implementations with their preferred ones, but there is no reason to provide ```sarah.Runner``` interface **for the same reason** because ```sarah.Runner``` is the core component that orchestrates other components.

# Problem
From a different point of view, however, there is a reason to provide public ```sarah.Runner``` interface with its private ```sarah.runner``` implementation: prevention of wrongful functional option execution. When a developer is not familiar with _Functional Options Pattern_, he may execute functional option where it is not expected. Below is an example:
```go
opt := sarah.WithBot(botInstance) // Returns sarah.RunnerOption
r, err := sarah.NewRunner(config.Runner) // sarah.RunnerOption(s) MUST be passed here as variadic arguments.
r.Run(context.TODO()) // Runs WITHOUT given botInstance.
opt(r) // This is NOT expected and does NOT work at all, but compiles successfully.
```

# Solution
One way to prevent this is to having an agreement *NOT* to do so; Another way is to let ```sarah.NewRunner()``` return ```sarah.Runner``` interface while ```sarah.RunnerOption``` receives ```*sarah.runner``` as argument. Second way could be preferred since a wrongful execution such as above example results in compile error. This pull request employs this.

# Further Readings
- [Self-referential functions and the design of options](https://commandcenter.blogspot.jp/2014/01/self-referential-functions-and-design.html)
- [Functional options for friendly APIs](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis)