### PR TITLE
To prevent future channel block, use channel close event to notify goroutine activation

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -545,13 +545,9 @@ func botSupervisor(runnerCtx context.Context, botType BotType, alerters *alerter
 	// Bot itself MUST NOT kill itself, but the Runner does. Beware that Runner takes care of all related components' lifecycle.
 	activated := make(chan struct{})
 	go func() {
-		signalVal := struct{}{} // avoid multiple construction
+		close(activated)
 		for {
 			select {
-			case activated <- signalVal:
-				// Send sentinel value to make sure this goroutine is all ready by the end of this method call.
-				// This blocks once the value is sent because of the nature of non-buffered channel and one-time subscription.
-
 			case e := <-errCh:
 				switch e.(type) {
 				case *BotNonContinuableError:


### PR DESCRIPTION
Currently [an unbuffered channel is used](https://github.com/oklahomer/go-sarah/blob/eb33a5d0238c5c31152d32760ff8d6141d592de8/runner.go#L546) to notify goroutine construction. This is to make sure, when [the initiating method](https://github.com/oklahomer/go-sarah/blob/eb33a5d0238c5c31152d32760ff8d6141d592de8/runner.go#L539) is finished, the goroutine is successfully created and ready to go. This implementation is O.K. so far, but can be error prone when additional complex logic comes before the [channel read](https://github.com/oklahomer/go-sarah/blob/eb33a5d0238c5c31152d32760ff8d6141d592de8/runner.go#L582).

This can be simplified and yet be robust by using `close`. This way, the closing part does not block even if the channel is not being read; and reading part is still guaranteed to wait till the channel is closed in the new goroutine.