### PR TITLE
Supply a type that represents retrial policy

### DIFF
--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -9,6 +9,25 @@ import (
 	"time"
 )
 
+func TestNewPolicy(t *testing.T) {
+	policy := NewPolicy()
+	if policy == nil {
+		t.Fatal("Expected retrial policy is not returned.")
+	}
+}
+
+func TestWithPolicy(t *testing.T) {
+	policy := &Policy{Trial: 1}
+	called := false
+	WithPolicy(policy, func() error {
+		called = true
+		return nil
+	})
+	if !called {
+		t.Error("Passed function is not called.")
+	}
+}
+
 func TestRetry(t *testing.T) {
 	trial := uint(3)
 


### PR DESCRIPTION
Currently `retry` package provides three methods for each designated purpose: `retry.Retry`, `retry.WithInterval` and `retry.WithBackOff`. However this is troublesome when developer tries to apply own retrial policy because each retrial method is hard coded.
This p-r aims to supply universal configuration variable, `retry.Policy`, and a retrial method, `retry.WithPolicy`. This should ease developers supply flexible retrial configuration.