### PR TITLE
Prefer retry.WithPolicy over other retrial methods

### DIFF
--- a/gitter/adapter.go
+++ b/gitter/adapter.go
@@ -49,10 +49,10 @@ func (adapter *Adapter) BotType() sarah.BotType {
 func (adapter *Adapter) Run(ctx context.Context, enqueueInput func(sarah.Input) error, notifyErr func(error)) {
 	// Get belonging rooms.
 	var rooms *Rooms
-	err := retry.WithInterval(adapter.config.RetryLimit, func() (e error) {
+	err := retry.WithPolicy(adapter.config.RetryPolicy, func() (e error) {
 		rooms, e = adapter.apiClient.Rooms(ctx)
 		return e
-	}, adapter.config.RetryInterval)
+	})
 	if err != nil {
 		notifyErr(sarah.NewBotNonContinuableError(err.Error()))
 		return
@@ -91,10 +91,10 @@ func (adapter *Adapter) runEachRoom(ctx context.Context, room *Room, enqueueInpu
 			log.Infof("connecting to room: %s", room.ID)
 
 			var conn Connection
-			err := retry.WithInterval(adapter.config.RetryLimit, func() (e error) {
+			err := retry.WithPolicy(adapter.config.RetryPolicy, func() (e error) {
 				conn, e = adapter.streamingClient.Connect(ctx, room)
 				return e
-			}, adapter.config.RetryInterval)
+			})
 			if err != nil {
 				log.Warnf("could not connect to room: %s. error: %s.", room.ID, err.Error())
 				return

--- a/gitter/adapter_test.go
+++ b/gitter/adapter_test.go
@@ -3,6 +3,7 @@ package gitter
 import (
 	"errors"
 	"github.com/oklahomer/go-sarah"
+	"github.com/oklahomer/go-sarah/retry"
 	"golang.org/x/net/context"
 	"reflect"
 	"testing"
@@ -141,8 +142,9 @@ func TestAdapter_runEachRoom(t *testing.T) {
 			},
 		},
 		config: &Config{
-			RetryLimit:    retryLimit,
-			RetryInterval: 1 * time.Millisecond,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 	}
 
@@ -183,8 +185,9 @@ func TestAdapter_runEachRoom_ConnectionInitializationError(t *testing.T) {
 			},
 		},
 		config: &Config{
-			RetryLimit:    retryLimit,
-			RetryInterval: 1 * time.Millisecond,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 	}
 
@@ -237,8 +240,9 @@ func TestAdapter_runEachRoom_ConnectionError(t *testing.T) {
 			},
 		},
 		config: &Config{
-			RetryLimit:    1,
-			RetryInterval: 1 * time.Millisecond,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 	}
 
@@ -277,8 +281,9 @@ func TestAdapter_Run(t *testing.T) {
 	roomID := "dummy"
 	adapter := &Adapter{
 		config: &Config{
-			RetryLimit:    1,
-			RetryInterval: 100 * time.Millisecond,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 		apiClient: &DummyAPIClient{
 			RoomsFunc: func(_ context.Context) (*Rooms, error) {
@@ -313,8 +318,9 @@ func TestAdapter_Run(t *testing.T) {
 func TestAdapter_Run_RestAPIClientRoomsError(t *testing.T) {
 	adapter := &Adapter{
 		config: &Config{
-			RetryLimit:    1,
-			RetryInterval: 100 * time.Millisecond,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 		apiClient: &DummyAPIClient{
 			RoomsFunc: func(_ context.Context) (*Rooms, error) {

--- a/gitter/config.go
+++ b/gitter/config.go
@@ -1,12 +1,14 @@
 package gitter
 
-import "time"
+import (
+	"github.com/oklahomer/go-sarah/retry"
+	"time"
+)
 
 // Config contains some configuration variables for gitter Adapter.
 type Config struct {
-	Token         string        `json:"token" yaml:"token"`
-	RetryLimit    uint          `json:"retry_limit" yaml:"retry_limit"`
-	RetryInterval time.Duration `json:"retry_interval" yaml:"retry_interval"`
+	Token       string        `json:"token" yaml:"token"`
+	RetryPolicy *retry.Policy `json:"retry_policy" yaml:"retry_policy"`
 }
 
 // NewConfig returns initialized Config struct with default settings.
@@ -14,8 +16,10 @@ type Config struct {
 // or direct assignment.
 func NewConfig() *Config {
 	return &Config{
-		Token:         "",
-		RetryLimit:    10,
-		RetryInterval: 500 * time.Millisecond,
+		Token: "",
+		RetryPolicy: &retry.Policy{
+			Trial:    10,
+			Interval: 500 * time.Millisecond,
+		},
 	}
 }

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -230,20 +230,20 @@ func (adapter *Adapter) superviseConnection(connCtx context.Context, payloadSend
 func (adapter *Adapter) connect(ctx context.Context) (rtmapi.Connection, error) {
 	// Get RTM session via Web API.
 	var rtmStart *webapi.RTMStart
-	err := retry.WithInterval(adapter.config.RetryLimit, func() (e error) {
+	err := retry.WithPolicy(adapter.config.RetryPolicy, func() (e error) {
 		rtmStart, e = adapter.client.StartRTMSession(ctx)
 		return e
-	}, adapter.config.RetryInterval)
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	// Establish WebSocket connection with given RTM session.
 	var conn rtmapi.Connection
-	err = retry.WithInterval(adapter.config.RetryLimit, func() (e error) {
+	err = retry.WithPolicy(adapter.config.RetryPolicy, func() (e error) {
 		conn, e = adapter.client.ConnectRTM(ctx, rtmStart.URL)
 		return e
-	}, adapter.config.RetryInterval)
+	})
 
 	return conn, err
 }

--- a/slack/adapter_test.go
+++ b/slack/adapter_test.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"errors"
 	"github.com/oklahomer/go-sarah"
+	"github.com/oklahomer/go-sarah/retry"
 	"github.com/oklahomer/golack/rtmapi"
 	"github.com/oklahomer/golack/slackobject"
 	"github.com/oklahomer/golack/webapi"
@@ -384,9 +385,10 @@ func TestAdapter_Run(t *testing.T) {
 
 	adapter := &Adapter{
 		config: &Config{
-			PingInterval:  100 * time.Second,
-			RetryInterval: 1 * time.Millisecond,
-			RetryLimit:    1,
+			PingInterval: 100 * time.Second,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 		client: client,
 	}
@@ -424,8 +426,9 @@ func TestAdapter_Run_ConnectionInitializationError(t *testing.T) {
 
 	adapter := &Adapter{
 		config: &Config{
-			RetryInterval: 1 * time.Millisecond,
-			RetryLimit:    1,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 		client: client,
 	}
@@ -483,9 +486,10 @@ func TestAdapter_Run_ConnectionAbortionError(t *testing.T) {
 
 	adapter := &Adapter{
 		config: &Config{
-			PingInterval:  100 * time.Second,
-			RetryInterval: 1 * time.Millisecond,
-			RetryLimit:    1,
+			PingInterval: 100 * time.Second,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 		client: client,
 	}
@@ -664,8 +668,9 @@ func TestAdapter_connect(t *testing.T) {
 
 	adapter := &Adapter{
 		config: &Config{
-			RetryInterval: 1 * time.Millisecond,
-			RetryLimit:    1,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 		client: client,
 	}
@@ -690,8 +695,9 @@ func TestAdapter_connect_error(t *testing.T) {
 
 	adapter := &Adapter{
 		config: &Config{
-			RetryInterval: 1 * time.Millisecond,
-			RetryLimit:    1,
+			RetryPolicy: &retry.Policy{
+				Trial: 1,
+			},
 		},
 		client: client,
 	}

--- a/slack/config.go
+++ b/slack/config.go
@@ -1,6 +1,9 @@
 package slack
 
-import "time"
+import (
+	"github.com/oklahomer/go-sarah/retry"
+	"time"
+)
 
 // Config contains some configuration variables for slack Adapter.
 type Config struct {
@@ -8,10 +11,9 @@ type Config struct {
 	HelpCommand      string        `json:"help_command" yaml:"help_command"`
 	AbortCommand     string        `json:"abort_command" yaml:"abort_command"`
 	SendingQueueSize uint          `json:"sending_queue_size" yaml:"sending_queue_size"`
-	RetryLimit       uint          `json:"retry_limit" yaml:"retry_limit"`
 	RequestTimeout   time.Duration `json:"request_timeout" yaml:"request_timeout"`
-	RetryInterval    time.Duration `json:"retry_interval" yaml:"retry_interval"`
 	PingInterval     time.Duration `json:"ping_interval" yaml:"ping_interval"`
+	RetryPolicy      *retry.Policy `json:"retry_policy" yaml:"retry_policy"`
 }
 
 // NewConfig returns initialized Config struct with default settings.
@@ -23,9 +25,11 @@ func NewConfig() *Config {
 		HelpCommand:      ".help",
 		AbortCommand:     ".abort",
 		SendingQueueSize: 100,
-		RetryLimit:       10,
 		RequestTimeout:   3 * time.Second,
-		RetryInterval:    500 * time.Millisecond,
 		PingInterval:     30 * time.Second,
+		RetryPolicy: &retry.Policy{
+			Trial:    10,
+			Interval: 500 * time.Millisecond,
+		},
 	}
 }


### PR DESCRIPTION
#57 introduced a new type that represents retrial policy. With this type and `retry.WithPolicy` combo., developers may provide retrial configuration with more flexibility. This should be preferred over the current implementation that states a specific method with specific retrial strategy: `retry.Retry`, `retry.WithInterval` and `retry.WithBackOff`.