### PR TITLE
Discard log output on regular test

### DIFF
--- a/develop/gb_manifest
+++ b/develop/gb_manifest
@@ -22,7 +22,7 @@
 		{
 			"importpath": "github.com/oklahomer/golack",
 			"repository": "https://github.com/oklahomer/golack",
-			"revision": "032a6393dca02740a6c55f2cb0215a5c3b6cc1c6",
+			"revision": "54f1368ad24f5c242eda960b22ab03fdc237538a",
 			"branch": "master"
 		},
 		{

--- a/gitter/adapter_test.go
+++ b/gitter/adapter_test.go
@@ -3,12 +3,29 @@ package gitter
 import (
 	"errors"
 	"github.com/oklahomer/go-sarah"
+	"github.com/oklahomer/go-sarah/log"
 	"github.com/oklahomer/go-sarah/retry"
 	"golang.org/x/net/context"
+	"io/ioutil"
+	stdLogger "log"
+	"os"
 	"reflect"
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	oldLogger := log.GetLogger()
+	defer log.SetLogger(oldLogger)
+
+	l := stdLogger.New(ioutil.Discard, "dummyLog", 0)
+	logger := log.NewWithStandardLogger(l)
+	log.SetLogger(logger)
+
+	code := m.Run()
+
+	os.Exit(code)
+}
 
 type DummyAPIClient struct {
 	RoomsFunc       func(context.Context) (*Rooms, error)

--- a/log/logger.go
+++ b/log/logger.go
@@ -176,6 +176,41 @@ func SetLogger(l Logger) {
 	logger = l
 }
 
+// GetLogger returns currently set Logger.
+// Once a preferred Logger implementation is set via log.SetLogger,
+// developer may use its method by calling this package's function: log.Debug, log.Debugf and others.
+//
+// However when developer wishes to retrieve the Logger instance, this function helps.
+// This is particularly useful in such situation where Logger implementation must be temporarily switched but must be
+// switched back when a task is done.
+// Example follows.
+//
+//	import (
+//		"github.com/oklahomer/go-sarah/log"
+//		"io/ioutil"
+//		stdLogger "log"
+//		"os"
+//		"testing"
+//	)
+//
+//	func TestMain(m *testing.M) {
+//		oldLogger := log.GetLogger()
+//		defer log.SetLogger(oldLogger)
+//
+//		l := stdLogger.New(ioutil.Discard, "dummyLog", 0)
+// 		logger := log.NewWithStandardLogger(l)
+//		log.SetLogger(logger)
+//
+//		code := m.Run()
+//
+//		os.Exit(code)
+//	}
+func GetLogger() Logger {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	return logger
+}
+
 // SetOutputLevel sets what logging level to output.
 // Application may call logging method any time, but Logger only outputs if the corresponding log level is equal to or higher than the level set here.
 // e.g. When InfoLevel is set, output with Debug() and Debugf() are ignored.

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -3,7 +3,7 @@ package retry
 import (
 	"errors"
 	"fmt"
-	"github.com/oklahomer/go-sarah/log"
+	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -101,7 +101,7 @@ func TestWithInterval(t *testing.T) {
 	interval := 100 * time.Millisecond
 	WithInterval(2, func() error {
 		i++
-		log.Error(i)
+		ioutil.Discard.Write([]byte("writing dummy output"))
 		if i == 1 {
 			startAt = time.Now()
 		} else {
@@ -126,7 +126,7 @@ func TestWithBackOff(t *testing.T) {
 	factor := 0.01
 	WithBackOff(2, func() error {
 		i++
-		log.Error(i)
+		ioutil.Discard.Write([]byte("writing dummy output"))
 		if i == 1 {
 			startAt = time.Now()
 		} else {

--- a/runner_test.go
+++ b/runner_test.go
@@ -2,13 +2,30 @@ package sarah
 
 import (
 	"errors"
+	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
+	"io/ioutil"
+	stdLogger "log"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sync"
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	oldLogger := log.GetLogger()
+	defer log.SetLogger(oldLogger)
+
+	l := stdLogger.New(ioutil.Discard, "dummyLog", 0)
+	logger := log.NewWithStandardLogger(l)
+	log.SetLogger(logger)
+
+	code := m.Run()
+
+	os.Exit(code)
+}
 
 type DummyWorker struct {
 	EnqueueFunc func(func()) error

--- a/watchers/dirwatcher_test.go
+++ b/watchers/dirwatcher_test.go
@@ -3,12 +3,29 @@ package watchers
 import (
 	"errors"
 	"github.com/fsnotify/fsnotify"
+	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
+	"io/ioutil"
+	stdLogger "log"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	oldLogger := log.GetLogger()
+	defer log.SetLogger(oldLogger)
+
+	l := stdLogger.New(ioutil.Discard, "dummyLog", 0)
+	logger := log.NewWithStandardLogger(l)
+	log.SetLogger(logger)
+
+	code := m.Run()
+
+	os.Exit(code)
+}
 
 type dummyInternalWatcher struct {
 	AddFunc    func(string) error

--- a/workers/worker_test.go
+++ b/workers/worker_test.go
@@ -4,11 +4,28 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	stdLogger "log"
+	"os"
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	oldLogger := log.GetLogger()
+	defer log.SetLogger(oldLogger)
+
+	l := stdLogger.New(ioutil.Discard, "dummyLog", 0)
+	logger := log.NewWithStandardLogger(l)
+	log.SetLogger(logger)
+
+	code := m.Run()
+
+	os.Exit(code)
+}
 
 type DummyReporter struct {
 	ReportFunc func(context.Context, *Stats)


### PR DESCRIPTION
When testing with `-v` option or when an error occurred, all standard output strings are printed as part of a test result and that becomes a noise.
To minimize the noise, discard log outputs unless the logging itself is the subject to test.