### PR TITLE
Add a mechanism to return Runner status when needed

### DIFF
--- a/status.go
+++ b/status.go
@@ -1,0 +1,126 @@
+package sarah
+
+import "sync"
+
+// Status represents the current status of the bot system including Runner and all registered Bots.
+type Status struct {
+	Running bool
+	Bots    []BotStatus
+}
+
+// BotStatus represents the current status of a Bot.
+type BotStatus struct {
+	Type    BotType
+	Running bool
+}
+
+type status struct {
+	bots     []*botStatus
+	finished chan struct{}
+	mutex    sync.RWMutex
+}
+
+func (s *status) running() bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	finished := s.finished
+	if finished == nil {
+		// NewRunner() is called, status instance is created, but Runner.Run() is not called yet.
+		// This channel field is populated when status.start() is called via Runner.Run().
+		return false
+	}
+
+	select {
+	case <-finished:
+		return false
+
+	default:
+		return true
+
+	}
+}
+
+func (s *status) start() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.finished = make(chan struct{})
+}
+
+func (s *status) addBot(bot Bot) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	botStatus := &botStatus{
+		botType:  bot.BotType(),
+		finished: make(chan struct{}),
+	}
+	s.bots = append(s.bots, botStatus)
+}
+
+func (s *status) stopBot(bot Bot) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for _, bs := range s.bots {
+		if bs.botType == bot.BotType() {
+			bs.stop()
+		}
+	}
+}
+
+func (s *status) snapshot() Status {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	snapshot := Status{
+		Running: s.running(),
+	}
+	for _, botStatus := range s.bots {
+		bs := BotStatus{
+			Type:    botStatus.botType,
+			Running: botStatus.running(),
+		}
+		snapshot.Bots = append(snapshot.Bots, bs)
+	}
+
+	return snapshot
+}
+
+func (s *status) stop() {
+	defer func() {
+		if recover() != nil {
+			// O.K.
+		}
+	}()
+
+	close(s.finished)
+}
+
+type botStatus struct {
+	botType  BotType
+	finished chan struct{}
+}
+
+func (bs *botStatus) running() bool {
+	select {
+	case <-bs.finished:
+		return false
+
+	default:
+		return true
+
+	}
+}
+
+func (bs *botStatus) stop() {
+	defer func() {
+		if recover() != nil {
+			// O.K.
+			// comes here when channel is already closed
+		}
+	}()
+
+	close(bs.finished)
+}

--- a/status.go
+++ b/status.go
@@ -1,6 +1,9 @@
 package sarah
 
-import "sync"
+import (
+	"github.com/oklahomer/go-sarah/log"
+	"sync"
+)
 
 // Status represents the current status of the bot system including Runner and all registered Bots.
 type Status struct {
@@ -92,6 +95,10 @@ func (s *status) stop() {
 	defer func() {
 		if recover() != nil {
 			// O.K.
+			// Comes here when channel is already closed.
+			// stop() is not expected to be called multiple times,
+			// but recover here to avoid panic.
+			log.Warn("Multiple status.stop() call occurred.")
 		}
 	}()
 
@@ -118,7 +125,10 @@ func (bs *botStatus) stop() {
 	defer func() {
 		if recover() != nil {
 			// O.K.
-			// comes here when channel is already closed
+			// Comes here when channel is already closed.
+			// stop() is not expected to be called multiple times,
+			// but recover here to avoid panic.
+			log.Warnf("Multiple botStatus.stop() call for %s occurred.", bs.botType)
 		}
 	}()
 

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,159 @@
+package sarah
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_status_start(t *testing.T) {
+	s := &status{}
+	s.start()
+
+	if s.finished == nil {
+		t.Error("A channel to judge running status must be set.")
+	}
+}
+
+func Test_status_stop(t *testing.T) {
+	s := &status{
+		finished: make(chan struct{}),
+	}
+
+	s.stop()
+
+	select {
+	case <-s.finished:
+		// O.K. Channel is closed.
+
+	case <-time.NewTimer(100 * time.Millisecond).C:
+		t.Error("A channel is not closed on status.stop.")
+
+	}
+
+	s.stop() // Multiple call to this method should not panic.
+}
+
+func Test_status_addBot(t *testing.T) {
+	botType := BotType("dummy")
+	bot := &DummyBot{BotTypeValue: botType}
+	s := &status{}
+	s.addBot(bot)
+
+	botStatuses := s.bots
+	if len(botStatuses) != 1 {
+		t.Fatal("Status for one and only one Bot should be set.")
+	}
+
+	bs := botStatuses[0]
+
+	if bs.botType != botType {
+		t.Errorf("Expected BotType is not set: %s.", bs.botType)
+	}
+
+	if !bs.running() {
+		t.Error("Bot status must be running at this point.")
+	}
+}
+
+func Test_status_stopBot(t *testing.T) {
+	botType := BotType("dummy")
+	bs := &botStatus{
+		botType:  botType,
+		finished: make(chan struct{}),
+	}
+	s := &status{
+		bots: []*botStatus{bs},
+	}
+
+	bot := &DummyBot{BotTypeValue: botType}
+	s.stopBot(bot)
+
+	botStatuses := s.bots
+	if len(botStatuses) != 1 {
+		t.Fatal("Status for one and only one Bot should be set.")
+	}
+
+	stored := botStatuses[0]
+
+	if stored.botType != botType {
+		t.Errorf("Expected BotType is not set: %s.", bs.botType)
+	}
+
+	if stored.running() {
+		t.Error("Bot status must not be running at this point.")
+	}
+}
+
+func Test_status_snapshot(t *testing.T) {
+	botType := BotType("dummy")
+	bs := &botStatus{
+		botType:  botType,
+		finished: make(chan struct{}),
+	}
+	s := &status{
+		bots:     []*botStatus{bs},
+		finished: make(chan struct{}),
+	}
+
+	snapshot := s.snapshot()
+	if !snapshot.Running {
+		t.Error("Status.Running should be true at this point.")
+	}
+
+	if len(snapshot.Bots) != 1 {
+		t.Errorf("The number of registered Bot should be one, but was %d.", len(snapshot.Bots))
+	}
+
+	if !snapshot.Bots[0].Running {
+		t.Error("BotStatus.Running should be true at this point.")
+	}
+
+	close(bs.finished)
+	close(s.finished)
+
+	snapshot = s.snapshot()
+
+	if snapshot.Running {
+		t.Error("Status.Running should be false at this point.")
+	}
+
+	if snapshot.Bots[0].Running {
+		t.Error("BotStatus.Running should be false at this point.")
+	}
+}
+
+func Test_botStatus_running(t *testing.T) {
+	bs := &botStatus{
+		botType:  "dummy",
+		finished: make(chan struct{}),
+	}
+
+	if !bs.running() {
+		t.Error("botStatus.running() should be true at this point.")
+	}
+
+	close(bs.finished)
+
+	if bs.running() {
+		t.Error("botStatus.running() should be false at this point.")
+	}
+}
+
+func Test_botStatus_stop(t *testing.T) {
+	bs := &botStatus{
+		finished: make(chan struct{}),
+	}
+
+	bs.stop()
+
+	select {
+	case <-bs.finished:
+		// O.K. Channel is closed.
+
+	case <-time.NewTimer(100 * time.Millisecond).C:
+		t.Error("A channel is not closed on botStatus.stop.")
+
+	}
+
+	bs.stop() // Multiple call to this method should not panic.
+}


### PR DESCRIPTION
Currently `Runner` reports the `Bot`'s critical state via registered `Alerter`. So, when the `Alerter` fails to send alert or the administrator fails to catch the alert, the state is not known.

This p-r tries to add a mechanism to access the status of `Runner` and its belonging `Bot`s. Such mechanism can be helpful when a HTTP server is served in the same process and an API endpoint returns the status.