### PR TITLE
Simplify bot supervisor logic to fix unstable test

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -287,7 +287,7 @@ func (r *runner) Run(ctx context.Context) {
 		log.Infof("starting %s", botType.String())
 
 		// Each Bot has its own context propagating Runner's lifecycle.
-		botCtx, errNotifier := botSupervisor(ctx, botType, r.alerters)
+		botCtx, errNotifier := superviseBot(ctx, botType, r.alerters)
 
 		// Prepare function that receives Input.
 		receiveInput := setupInputReceiver(botCtx, bot, r.worker)
@@ -559,7 +559,7 @@ func executeScheduledTask(ctx context.Context, bot Bot, task ScheduledTask) {
 	}
 }
 
-func botSupervisor(runnerCtx context.Context, botType BotType, alerters *alerters) (context.Context, func(error)) {
+func superviseBot(runnerCtx context.Context, botType BotType, alerters *alerters) (context.Context, func(error)) {
 	botCtx, cancel := context.WithCancel(runnerCtx)
 
 	// A function that receives an escalated error from Bot.

--- a/runner_test.go
+++ b/runner_test.go
@@ -920,7 +920,7 @@ func Test_executeScheduledTask(t *testing.T) {
 	}
 }
 
-func Test_botSupervisor(t *testing.T) {
+func Test_superviseBot(t *testing.T) {
 	rootCxt := context.Background()
 	alerted := make(chan bool)
 	alerters := &alerters{
@@ -936,7 +936,7 @@ func Test_botSupervisor(t *testing.T) {
 			},
 		},
 	}
-	botCtx, errSupervisor := botSupervisor(rootCxt, "DummyBotType", alerters)
+	botCtx, errSupervisor := superviseBot(rootCxt, "DummyBotType", alerters)
 
 	select {
 	case <-botCtx.Done():


### PR DESCRIPTION
Every once in a while a daily CI job fails with the following message:
```
36.09s$ go test -race ./...
--- FAIL: Test_botSupervisor (20.00s)
	runner_test.go:954: Bot context should be canceled at this point.
	runner_test.go:957: botCtx.Err() must return context.Canceled, but was <nil>
	runner_test.go:963: Alert should be sent at this point.
FAIL
FAIL	github.com/oklahomer/go-sarah	23.192s
```
ref. https://travis-ci.org/oklahomer/go-sarah/jobs/512633940

CI history shows higher reproduction rate with go 1.8, but is not 100% limited to 1.8.
This is guaranteed that the supervising goroutine is already activated at below point.
https://github.com/oklahomer/go-sarah/blob/7f623ec46b4e4615d01f2f285a79aecefa1dc598/runner.go#L598-L601
But it seems like the loop in the supervising goroutine that subscribes to a non-buffered channel, `chan error`, is not running yet and hence the enqueued error is ignored in `select` statement.
https://github.com/oklahomer/go-sarah/blob/7f623ec46b4e4615d01f2f285a79aecefa1dc598/runner.go#L608-L613

The supervisor's logic itself is a bit too complicated considering the simplicity of the responsibility. A refactoring is preferred and its side effect should fix such instability.