### PR TITLE
Pass sarah.Input to sarah.Command on help request

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ func main() {
 var GuessProps = sarah.NewCommandPropsBuilder().
 	BotType(slack.SLACK).
 	Identifier("guess").
-	InputExample(".guess").
+	Instruction("Input .guess to start a game.").
 	MatchFunc(func(input sarah.Input) bool {
 		return strings.HasPrefix(strings.TrimSpace(input.Message()), ".guess")
 	}).
@@ -144,8 +144,13 @@ func (hello *HelloCommand) Execute(context.Context, sarah.Input) (*sarah.Command
 	return slack.NewStringResponse("Hello!"), nil
 }
 
-func (hello *HelloCommand) InputExample() string {
-	return ".hello"
+func (hello *HelloCommand) Instruction(input *sarah.HelpInput) string {
+	if 12 < input.SentAt().Hour() {
+		// This command is only active in the morning.
+		// Do not show instruction in the afternoon.
+		return ""
+	}
+	return "Input .hello to greet"
 }
 
 func (hello *HelloCommand) Match(input sarah.Input) bool {

--- a/bot.go
+++ b/bot.go
@@ -126,10 +126,10 @@ func (bot *defaultBot) Respond(ctx context.Context, input Input) error {
 	var err error
 	if nextFunc == nil {
 		// If no conversational context is stored, simply search for corresponding command.
-		switch input.(type) {
+		switch in := input.(type) {
 		case *HelpInput:
 			res = &CommandResponse{
-				Content:     bot.commands.Helps(),
+				Content:     bot.commands.Helps(in),
 				UserContext: nil,
 			}
 		default:
@@ -192,5 +192,3 @@ func NewSuppressedResponseWithNext(next ContextualFunc) *CommandResponse {
 		UserContext: NewUserContext(next),
 	}
 }
-
-type botRunner struct{}

--- a/bot_test.go
+++ b/bot_test.go
@@ -462,7 +462,7 @@ func TestDefaultBot_Respond_Help(t *testing.T) {
 	example := "e.g."
 	cmd := &DummyCommand{
 		IdentifierValue: commandID,
-		InputExampleFunc: func() string {
+		InstructionFunc: func(_ *HelpInput) string {
 			return example
 		},
 	}
@@ -482,8 +482,14 @@ func TestDefaultBot_Respond_Help(t *testing.T) {
 	}
 
 	dest := "destination"
-	dummyInput := NewHelpInput("sender", "message", time.Now(), dest)
-	err := myBot.Respond(context.TODO(), dummyInput)
+	dummyInput := &DummyInput{
+		SenderKeyValue: "sender",
+		MessageValue:   "message",
+		SentAtValue:    time.Now(),
+		ReplyToValue:   dest,
+	}
+	helpInput := NewHelpInput(dummyInput)
+	err := myBot.Respond(context.TODO(), helpInput)
 	if err != nil {
 		t.Errorf("Unexpected error is returned: %#v.", err)
 	}
@@ -498,8 +504,8 @@ func TestDefaultBot_Respond_Help(t *testing.T) {
 	if (*helps)[0].Identifier != commandID {
 		t.Errorf("Expected ID was not returned: %s.", (*helps)[0].Identifier)
 	}
-	if (*helps)[0].InputExample != example {
-		t.Errorf("Expected example was not returned: %s.", (*helps)[0].InputExample)
+	if (*helps)[0].Instruction != example {
+		t.Errorf("Expected example was not returned: %s.", (*helps)[0].Instruction)
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -562,22 +562,28 @@ func TestCommands_Append(t *testing.T) {
 }
 
 func TestCommands_Helps(t *testing.T) {
-	cmd := &DummyCommand{
+	cmd1 := &DummyCommand{
 		IdentifierValue: "id",
 		InstructionFunc: func(_ *HelpInput) string {
 			return "example"
 		},
 	}
-	commands := &Commands{collection: []Command{cmd}}
+	cmd2 := &DummyCommand{
+		IdentifierValue: "hiddenCommand",
+		InstructionFunc: func(_ *HelpInput) string {
+			return ""
+		},
+	}
+	commands := &Commands{collection: []Command{cmd1, cmd2}}
 
 	helps := commands.Helps(&HelpInput{})
 	if len(*helps) != 1 {
 		t.Fatalf("Expectnig one help to be given, but was %d.", len(*helps))
 	}
-	if (*helps)[0].Identifier != cmd.IdentifierValue {
+	if (*helps)[0].Identifier != cmd1.IdentifierValue {
 		t.Errorf("Expected ID was not returned: %s.", (*helps)[0].Identifier)
 	}
-	if (*helps)[0].Instruction != cmd.InstructionFunc(&HelpInput{}) {
+	if (*helps)[0].Instruction != cmd1.InstructionFunc(&HelpInput{}) {
 		t.Errorf("Expected instruction was not returned: %s.", (*helps)[0].Instruction)
 	}
 }

--- a/examples/simple/plugins/count/props.go
+++ b/examples/simple/plugins/count/props.go
@@ -39,7 +39,7 @@ var globalCounter = &counter{
 var SlackProps = sarah.NewCommandPropsBuilder().
 	BotType(slack.SLACK).
 	Identifier("counter").
-	InputExample(".count").
+	Instruction("Input .count to count up").
 	MatchPattern(regexp.MustCompile(`^\.count`)).
 	Func(func(_ context.Context, _ sarah.Input) (*sarah.CommandResponse, error) {
 		return slack.NewStringResponse(fmt.Sprint(globalCounter.increment())), nil
@@ -50,7 +50,7 @@ var SlackProps = sarah.NewCommandPropsBuilder().
 var GitterProps = sarah.NewCommandPropsBuilder().
 	BotType(gitter.GITTER).
 	Identifier("counter").
-	InputExample(".count").
+	Instruction("Input .count to count up").
 	MatchPattern(regexp.MustCompile(`^\.count`)).
 	Func(func(_ context.Context, _ sarah.Input) (*sarah.CommandResponse, error) {
 		return gitter.NewStringResponse(fmt.Sprint(globalCounter.increment())), nil

--- a/examples/simple/plugins/echo/command.go
+++ b/examples/simple/plugins/echo/command.go
@@ -30,8 +30,8 @@ func (c *command) Execute(_ context.Context, input sarah.Input) (*sarah.CommandR
 	return slack.NewStringResponse(sarah.StripMessage(matchPattern, input.Message())), nil
 }
 
-// InputExample provides input example for user.
-func (c *command) InputExample() string {
+// Instruction provides input instruction for user.
+func (c *command) Instruction(_ *sarah.HelpInput) string {
 	return ".echo foo"
 }
 

--- a/examples/simple/plugins/guess/props.go
+++ b/examples/simple/plugins/guess/props.go
@@ -24,7 +24,7 @@ import (
 var SlackProps = sarah.NewCommandPropsBuilder().
 	BotType(slack.SLACK).
 	Identifier("guess").
-	InputExample(".guess").
+	Instruction("Input .guess to start a game.").
 	MatchFunc(func(input sarah.Input) bool {
 		return strings.HasPrefix(strings.TrimSpace(input.Message()), ".guess")
 	}).

--- a/examples/simple/plugins/hello/props.go
+++ b/examples/simple/plugins/hello/props.go
@@ -23,7 +23,7 @@ import (
 var SlackProps = sarah.NewCommandPropsBuilder().
 	BotType(slack.SLACK).
 	Identifier("hello").
-	InputExample(".hello").
+	Instruction("Input .hello to greet").
 	MatchFunc(func(input sarah.Input) bool {
 		return strings.HasPrefix(input.Message(), ".hello")
 	}).

--- a/examples/simple/plugins/morning/props.go
+++ b/examples/simple/plugins/morning/props.go
@@ -18,7 +18,16 @@ import (
 var SlackProps = sarah.NewCommandPropsBuilder().
 	BotType(slack.SLACK).
 	Identifier("morning").
-	InputExample(".morning").
+	InstructionFunc(func(input *sarah.HelpInput) string {
+		hour := time.Now().Hour()
+		if 12 < hour {
+			// This command is only active in the morning.
+			// Do not show instruction in the afternoon.
+			return ""
+		}
+
+		return "Input .morning to greet."
+	}).
 	MatchFunc(func(input sarah.Input) bool {
 		// 1. See if the input message starts with ".morning"
 		match := strings.HasPrefix(input.Message(), ".morning")

--- a/examples/simple/plugins/todo/command.go
+++ b/examples/simple/plugins/todo/command.go
@@ -66,8 +66,8 @@ func (cmd *command) Execute(_ context.Context, input sarah.Input) (*sarah.Comman
 	return slack.NewStringResponseWithNext("Please input due date in YYYY-MM-DD format", next), nil
 }
 
-func (cmd *command) InputExample() string {
-	return ".todo buy milk"
+func (cmd *command) Instruction(_ *sarah.HelpInput) string {
+	return `Input ".todo buy milk" to add "buy milk" to your TODO list.`
 }
 
 func (cmd *command) Match(input sarah.Input) bool {

--- a/input_test.go
+++ b/input_test.go
@@ -33,19 +33,28 @@ func TestNewHelpInput(t *testing.T) {
 	message := "Hello, 世界."
 	sentAt := time.Now()
 	dest := "100 N University Dr Edmond, OK"
-	input := NewHelpInput(senderKey, message, sentAt, dest)
+	input := &DummyInput{
+		SenderKeyValue: senderKey,
+		MessageValue:   message,
+		SentAtValue:    sentAt,
+		ReplyToValue:   dest,
+	}
+	helpInput := NewHelpInput(input)
 
-	if input.SenderKey() != senderKey {
+	if helpInput.SenderKey() != senderKey {
 		t.Errorf("Expected sender key was not returned: %s.", senderKey)
 	}
-	if input.Message() != message {
+	if helpInput.Message() != message {
 		t.Errorf("Expected message was not returned: %s.", message)
 	}
-	if input.SentAt() != sentAt {
+	if helpInput.SentAt() != sentAt {
 		t.Errorf("Expected time was not returned: %s.", sentAt.String())
 	}
-	if input.ReplyTo() != dest {
+	if helpInput.ReplyTo() != dest {
 		t.Errorf("Expected reply destination was not returned: %s.", dest)
+	}
+	if helpInput.OriginalInput != input {
+		t.Errorf("Original Input value is not set: %#v", helpInput.OriginalInput)
 	}
 }
 
@@ -54,18 +63,27 @@ func TestNewAbortInput(t *testing.T) {
 	message := "Hello, 世界."
 	sentAt := time.Now()
 	dest := "100 N University Dr Edmond, OK"
-	input := NewAbortInput(senderKey, message, sentAt, dest)
+	input := &DummyInput{
+		SenderKeyValue: senderKey,
+		MessageValue:   message,
+		SentAtValue:    sentAt,
+		ReplyToValue:   dest,
+	}
+	abortInput := NewAbortInput(input)
 
-	if input.SenderKey() != senderKey {
+	if abortInput.SenderKey() != senderKey {
 		t.Errorf("Expected sender key was not returned: %s.", senderKey)
 	}
-	if input.Message() != message {
+	if abortInput.Message() != message {
 		t.Errorf("Expected message was not returned: %s.", message)
 	}
-	if input.SentAt() != sentAt {
+	if abortInput.SentAt() != sentAt {
 		t.Errorf("Expected time was not returned: %s.", sentAt.String())
 	}
-	if input.ReplyTo() != dest {
+	if abortInput.ReplyTo() != dest {
 		t.Errorf("Expected reply destination was not returned: %s.", dest)
+	}
+	if abortInput.OriginalInput != input {
+		t.Errorf("Original Input value is not set: %#v", abortInput.OriginalInput)
 	}
 }

--- a/plugins/echo/echo.go
+++ b/plugins/echo/echo.go
@@ -45,7 +45,7 @@ var SlackProps = sarah.NewCommandPropsBuilder().
 	Identifier(identifier).
 	MatchPattern(matchPattern).
 	Func(SlackCommandFunc).
-	InputExample(".echo knock knock").
+	Instruction(".echo knock knock").
 	MustBuild()
 
 // GitterProps is a pre-built echo command properties for Slack.
@@ -54,5 +54,5 @@ var GitterProps = sarah.NewCommandPropsBuilder().
 	Identifier(identifier).
 	MatchPattern(matchPattern).
 	Func(GitterCommandFunc).
-	InputExample(".echo knock knock").
+	Instruction(".echo knock knock").
 	MustBuild()

--- a/plugins/hello/command.go
+++ b/plugins/hello/command.go
@@ -22,7 +22,7 @@ var slackFunc = func(_ context.Context, _ sarah.Input) (*sarah.CommandResponse, 
 var SlackProps = sarah.NewCommandPropsBuilder().
 	BotType(slack.SLACK).
 	Identifier("hello").
-	InputExample(".hello").
+	Instruction("Input .hello to greet.").
 	MatchPattern(regexp.MustCompile(`\.hello`)).
 	Func(slackFunc).
 	MustBuild()

--- a/plugins/worldweather/weather.go
+++ b/plugins/worldweather/weather.go
@@ -42,7 +42,7 @@ var SlackProps = sarah.NewCommandPropsBuilder().
 	BotType(slack.SLACK).
 	Identifier("weather").
 	ConfigurableFunc(NewCommandConfig(), SlackCommandFunc).
-	InputExample(".weather tokyo").
+	Instruction(`Input ".weather" followed by city name e.g. ".weather tokyo"`).
 	MatchPattern(MatchPattern).
 	MustBuild()
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -463,7 +463,9 @@ func Test_runner_runBot(t *testing.T) {
 			commandFunc: func(_ context.Context, _ Input, _ ...CommandConfig) (*CommandResponse, error) {
 				return nil, nil
 			},
-			example: ".echo foo",
+			instructionFunc: func(_ *HelpInput) string {
+				return ".echo foo"
+			},
 		}
 
 		// Prepare scheduled task to be configured on the fly
@@ -930,7 +932,9 @@ func Test_updateCommandConfig(t *testing.T) {
 				commandFunc: func(_ context.Context, _ Input, _ ...CommandConfig) (*CommandResponse, error) { return nil, nil },
 				matchFunc:   func(_ Input) bool { return true },
 				config:      nil,
-				example:     "exampleInput",
+				instructionFunc: func(_ *HelpInput) string {
+					return "instruction text"
+				},
 			},
 			{
 				identifier:  "dummy",
@@ -938,7 +942,9 @@ func Test_updateCommandConfig(t *testing.T) {
 				commandFunc: func(_ context.Context, _ Input, _ ...CommandConfig) (*CommandResponse, error) { return nil, nil },
 				matchFunc:   func(_ Input) bool { return true },
 				config:      c,
-				example:     "exampleInput",
+				instructionFunc: func(_ *HelpInput) string {
+					return "instruction text"
+				},
 			},
 		}
 
@@ -983,7 +989,9 @@ func Test_updateCommandConfig_WithBrokenYaml(t *testing.T) {
 				commandFunc: func(_ context.Context, _ Input, _ ...CommandConfig) (*CommandResponse, error) { return nil, nil },
 				matchFunc:   func(_ Input) bool { return true },
 				config:      c,
-				example:     "exampleInput",
+				instructionFunc: func(_ *HelpInput) string {
+					return "instruction text"
+				},
 			},
 		}
 
@@ -1028,7 +1036,9 @@ func Test_updateCommandConfig_WithConfigValue(t *testing.T) {
 				commandFunc: func(_ context.Context, _ Input, _ ...CommandConfig) (*CommandResponse, error) { return nil, nil },
 				matchFunc:   func(_ Input) bool { return true },
 				config:      c,
-				example:     "exampleInput",
+				instructionFunc: func(_ *HelpInput) string {
+					return "instruction text"
+				},
 			},
 		}
 

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -299,11 +299,11 @@ func handlePayload(_ context.Context, config *Config, payload rtmapi.DecodedPayl
 		trimmed := strings.TrimSpace(input.Message())
 		if config.HelpCommand != "" && trimmed == config.HelpCommand {
 			// Help command
-			help := sarah.NewHelpInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
+			help := sarah.NewHelpInput(input)
 			_ = enqueueInput(help)
 		} else if config.AbortCommand != "" && trimmed == config.AbortCommand {
 			// Abort command
-			abort := sarah.NewAbortInput(input.SenderKey(), input.Message(), input.SentAt(), input.ReplyTo())
+			abort := sarah.NewAbortInput(input)
 			_ = enqueueInput(abort)
 		} else {
 			// Regular input
@@ -369,17 +369,17 @@ func (adapter *Adapter) SendMessage(ctx context.Context, output sarah.Output) {
 			return
 		}
 
-		fields := []*webapi.AttachmentField{}
+		var fields []*webapi.AttachmentField
 		for _, commandHelp := range *output.Content().(*sarah.CommandHelps) {
 			fields = append(fields, &webapi.AttachmentField{
 				Title: commandHelp.Identifier,
-				Value: commandHelp.InputExample,
+				Value: commandHelp.Instruction,
 				Short: false,
 			})
 		}
 		attachments := []*webapi.MessageAttachment{
 			{
-				Fallback: "Here are some input examples.", // TODO
+				Fallback: "Here are some input instructions.",
 				Pretext:  "Help:",
 				Title:    "",
 				Fields:   fields,

--- a/slack/adapter_test.go
+++ b/slack/adapter_test.go
@@ -572,8 +572,8 @@ func TestAdapter_SendMessage_CommandHelps(t *testing.T) {
 
 	helps := &sarah.CommandHelps{
 		&sarah.CommandHelp{
-			Identifier:   "id",
-			InputExample: ".help",
+			Identifier:  "id",
+			Instruction: ".help",
 		},
 	}
 


### PR DESCRIPTION
This solves #71.

`sarah.Command`'s Interface may also change to reflect more practical use-cases. Current method name, `Command.InputExample`, suggests that a text representation of an input example is returned to support the sender. However, `Command.Match()` and `Command.Execute` allows non-text input to come. e.g. An image is posted to a group and a command named `similarImageFinder` searches for a similar image and returns it to the sender. Then what **string message** should `Command.InputExample` return as **an example of user input**?

To solve the inconsistency introduced above, `Command.InputExample` can be renamed to `Command.Instruction()` or something similar. With that naming, this is natural to return both input example such as "input '.image Homer Simpson'" and instruction such as "send an image to search for a similar image."

This loosely incorporate with #69.