### PR TITLE
Use xerrors instead of standard errors package

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -1,8 +1,8 @@
 package sarah
 
 import (
-	"fmt"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"strings"
 )
 
@@ -46,7 +46,7 @@ func (a *alerters) alertAll(ctx context.Context, botType BotType, err error) err
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					alertErrs.appendError(fmt.Errorf("panic on Alerter.Alert: %#v", r))
+					alertErrs.appendError(xerrors.Errorf("panic on Alerter.Alert: %w", r))
 				}
 			}()
 			err := alerter.Alert(ctx, botType, err)

--- a/alerter/line/client.go
+++ b/alerter/line/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oklahomer/go-sarah"
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
+	"golang.org/x/xerrors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -65,7 +66,7 @@ func (c *Client) Alert(ctx context.Context, botType sarah.BotType, err error) er
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("response status error. Status: %d", resp.StatusCode)
+		return xerrors.Errorf("response status %d is returned", resp.StatusCode)
 	}
 
 	return nil

--- a/bot.go
+++ b/bot.go
@@ -138,7 +138,7 @@ func (bot *defaultBot) Respond(ctx context.Context, input Input) error {
 	} else {
 		e := bot.userContextStorage.Delete(senderKey)
 		if e != nil {
-			log.Warnf("Failed to delete UserContext: BotType: %s. SenderKey: %s. Error: %s.", bot.BotType(), senderKey, e.Error())
+			log.Warnf("Failed to delete UserContext: BotType: %s. SenderKey: %s. Error: %+v", bot.BotType(), senderKey, e)
 		}
 
 		switch input.(type) {
@@ -162,7 +162,7 @@ func (bot *defaultBot) Respond(ctx context.Context, input Input) error {
 	// This may damage user experience since user is left in conversational context set by CommandResponse without any sort of notification.
 	if res.UserContext != nil && bot.userContextStorage != nil {
 		if err := bot.userContextStorage.Set(senderKey, res.UserContext); err != nil {
-			log.Errorf("Failed to store UserContext. BotType: %s. SenderKey: %s. UserContext: %#v.", bot.BotType(), senderKey, res.UserContext)
+			log.Errorf("Failed to store UserContext. BotType: %s. SenderKey: %s. UserContext: %#v. Error: %+v", bot.BotType(), senderKey, res.UserContext, err)
 		}
 	}
 	if res.Content != nil {

--- a/command.go
+++ b/command.go
@@ -1,10 +1,9 @@
 package sarah
 
 import (
-	"errors"
-	"fmt"
 	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"os"
 	"reflect"
 	"regexp"
@@ -15,7 +14,7 @@ import (
 var (
 	// ErrCommandInsufficientArgument depicts an error that not enough arguments are set to CommandProps.
 	// This is returned on CommandProps.Build() inside of runner.Run()
-	ErrCommandInsufficientArgument = errors.New("BotType, Identifier, InstructionFunc, MatchFunc and (Configurable)Func must be set.")
+	ErrCommandInsufficientArgument = xerrors.New("BotType, Identifier, InstructionFunc, MatchFunc and (Configurable)Func must be set.")
 )
 
 // CommandResponse is returned by Command or Task when the execution is finished.
@@ -139,7 +138,7 @@ func buildCommand(props *CommandProps, file *pluginConfigFile) (Command, error) 
 		return e
 	}()
 	if err != nil && os.IsNotExist(err) {
-		return nil, fmt.Errorf("config file property was given, but failed to locate it: %s", err.Error())
+		return nil, xerrors.Errorf("config file property was given, but failed to locate it: %w", err)
 	} else if err != nil {
 		// File was there, but could not read.
 		return nil, err
@@ -394,7 +393,7 @@ func (builder *CommandPropsBuilder) Build() (*CommandProps, error) {
 func (builder *CommandPropsBuilder) MustBuild() *CommandProps {
 	props, err := builder.Build()
 	if err != nil {
-		panic(fmt.Sprintf("Error on building CommandProps: %s", err.Error()))
+		panic(xerrors.Errorf("error on building CommandProps: %w", err))
 	}
 
 	return props

--- a/examples/simple/plugins/todo/command.go
+++ b/examples/simple/plugins/todo/command.go
@@ -139,7 +139,7 @@ func (cmd *command) inputTime(_ context.Context, input sarah.Input, validDate st
 	due, err := time.Parse("2006-01-02 15:04", fmt.Sprintf("%s %s", validDate, t))
 	if err != nil {
 		// Should not reach here since previous time parse succeeded.
-		log.Error("Failed to parse due date: %s", err.Error())
+		log.Error("Failed to parse due date: %+v", err)
 		return slack.NewStringResponse("Fatal error occurred."), nil
 	}
 

--- a/examples/status/config.go
+++ b/examples/status/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/oklahomer/go-sarah"
 	"github.com/oklahomer/go-sarah/slack"
 	"github.com/oklahomer/go-sarah/workers"
+	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 )
@@ -11,7 +12,7 @@ import (
 func readConfig(path string) (*config, error) {
 	body, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to read file: %w", err)
 	}
 
 	// Populate with default configuration value by calling each constructor.
@@ -23,7 +24,7 @@ func readConfig(path string) (*config, error) {
 	}
 	err = yaml.Unmarshal(body, c)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to read yaml: %w", err)
 	}
 
 	return c, nil

--- a/examples/status/handler.go
+++ b/examples/status/handler.go
@@ -82,7 +82,7 @@ func setStatusHandler(mux *http.ServeMux, ws *workerStats) {
 			writer.Header().Set("Content-Type", "application/json")
 			_, _ = writer.Write(bytes)
 		} else {
-			log.Errorf("failed to parse json: %s", err.Error())
+			log.Errorf("failed to parse json: %+v", err)
 			http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 	})

--- a/examples/status/main.go
+++ b/examples/status/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oklahomer/go-sarah/slack"
 	"github.com/oklahomer/go-sarah/workers"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"os"
 	"os/signal"
 	"time"
@@ -79,11 +80,11 @@ func setupSlackBot(cfg *config) (sarah.Bot, error) {
 	storage := sarah.NewUserContextStorage(cfg.ContextCache)
 	slackAdapter, err := slack.NewAdapter(cfg.Slack)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to initialize Slack adapter: %w", err)
 	}
 	slackBot, err := sarah.NewBot(slackAdapter, sarah.BotWithStorage(storage))
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to initialize Bot with given Slack adapter: %w", err)
 	}
 	return slackBot, nil
 }

--- a/examples/status/server_go18.go
+++ b/examples/status/server_go18.go
@@ -28,6 +28,6 @@ func (s *server) Run(ctx context.Context) {
 	<-ctx.Done()
 	err := s.sv.Shutdown(ctx)
 	if err != nil {
-		log.Errorf("Failed to stop HTTP server: %s.", err.Error())
+		log.Errorf("Failed to stop HTTP server: %+v", err)
 	}
 }

--- a/gitter/adapter.go
+++ b/gitter/adapter.go
@@ -5,6 +5,7 @@ import (
 	"github.com/oklahomer/go-sarah/log"
 	"github.com/oklahomer/go-sarah/retry"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -33,7 +34,7 @@ func NewAdapter(config *Config, options ...AdapterOption) (*Adapter, error) {
 	for _, opt := range options {
 		err := opt(adapter)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("failed to apply options: %w", err)
 		}
 	}
 
@@ -73,10 +74,11 @@ func (adapter *Adapter) SendMessage(ctx context.Context, output sarah.Output) {
 			log.Errorf("Destination is not instance of Room. %#v.", output.Destination())
 			return
 		}
-		_, _ = adapter.apiClient.PostMessage(ctx, room, content)
+		_, err := adapter.apiClient.PostMessage(ctx, room, content)
+		log.Errorf("Failed posting message to %s: %+v", room.ID, err)
 
 	default:
-		log.Warnf("unexpected output %#v", output)
+		log.Warnf("Unexpected output %#v", output)
 
 	}
 }
@@ -88,7 +90,7 @@ func (adapter *Adapter) runEachRoom(ctx context.Context, room *Room, enqueueInpu
 			return
 
 		default:
-			log.Infof("connecting to room: %s", room.ID)
+			log.Infof("Connecting to room: %s", room.ID)
 
 			var conn Connection
 			err := retry.WithPolicy(adapter.config.RetryPolicy, func() (e error) {
@@ -96,7 +98,7 @@ func (adapter *Adapter) runEachRoom(ctx context.Context, room *Room, enqueueInpu
 				return e
 			})
 			if err != nil {
-				log.Warnf("could not connect to room: %s. error: %s.", room.ID, err.Error())
+				log.Warnf("Could not connect to room: %s. Error: %+v", room.ID, err)
 				return
 			}
 
@@ -108,32 +110,33 @@ func (adapter *Adapter) runEachRoom(ctx context.Context, room *Room, enqueueInpu
 			// But, the truth is, given error is just a privately defined error instance given by http package.
 			// var errRequestCanceled = errors.New("net/http: request canceled")
 			// For now, let error log appear and proceed to next loop, select case with ctx.Done() will eventually return.
-			log.Error(connErr.Error())
+			log.Errorf("Disconnected from room %s: %+v", room.ID, connErr)
 
 		}
 	}
 }
 
 func receiveMessageRecursive(messageReceiver MessageReceiver, enqueueInput func(sarah.Input) error) error {
-	log.Infof("start receiving message")
+	log.Infof("Start receiving message")
 	for {
 		message, err := messageReceiver.Receive()
 
-		if err == ErrEmptyPayload {
+		var malformedErr *MalformedPayloadError
+		if xerrors.Is(err, ErrEmptyPayload) {
 			// https://developer.gitter.im/docs/streaming-api
 			// Parsers must be tolerant of occasional extra newline characters placed between messages.
 			// These characters are sent as periodic "keep-alive" messages to tell clients and NAT firewalls
 			// that the connection is still alive during low message volume periods.
 			continue
 
-		} else if malformedErr, ok := err.(*MalformedPayloadError); ok {
-			log.Warnf("skipping malformed input: %s", malformedErr)
+		} else if xerrors.As(err, &malformedErr) {
+			log.Warnf("Skipping malformed input: %+v", err)
 			continue
 
 		} else if err != nil {
 			// At this point, assume connection is unstable or is closed.
 			// Let caller proceed to reconnect or quit.
-			return err
+			return xerrors.Errorf("failed to receive input: %w", err)
 
 		}
 

--- a/gitter/adapter_test.go
+++ b/gitter/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oklahomer/go-sarah/log"
 	"github.com/oklahomer/go-sarah/retry"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"io/ioutil"
 	stdLogger "log"
 	"os"
@@ -79,7 +80,7 @@ func TestNewAdapter_WithOptionError(t *testing.T) {
 		return expectedErr
 	})
 
-	if err != expectedErr {
+	if !xerrors.Is(err, expectedErr) {
 		t.Errorf("Expected error is not returned: %#v.", err)
 	}
 

--- a/gitter/connection.go
+++ b/gitter/connection.go
@@ -4,16 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/oklahomer/go-sarah"
+	"golang.org/x/xerrors"
 	"io"
 	"time"
 )
 
 var (
 	// ErrEmptyPayload is an error that represents empty payload.
-	ErrEmptyPayload = errors.New("empty payload was given")
+	ErrEmptyPayload = xerrors.New("empty payload was given")
 )
 
 // MessageReceiver defines an interface that receives RoomMessage.

--- a/gitter/rest.go
+++ b/gitter/rest.go
@@ -5,6 +5,7 @@ import (
 	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
+	"golang.org/x/xerrors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -73,7 +74,7 @@ func (client *RestAPIClient) Get(ctx context.Context, resourceFragments []string
 		return err
 	}
 	if err := json.Unmarshal(body, &intf); err != nil {
-		log.Errorf("can not unmarshal given JSON structure: %s", string(body))
+		log.Errorf("Can not unmarshal given JSON structure: %s. Error: %+v", string(body), err)
 		return err
 	}
 
@@ -113,7 +114,7 @@ func (client *RestAPIClient) Post(ctx context.Context, resourceFragments []strin
 		return err
 	}
 	if err := json.Unmarshal(body, &responsePayload); err != nil {
-		log.Errorf("can not unmarshal given JSON structure: %s", string(body))
+		log.Errorf("Can not unmarshal given JSON structure: %s. Error: %+v", string(body), err)
 		return err
 	}
 
@@ -133,9 +134,9 @@ func (client *RestAPIClient) Rooms(ctx context.Context) (*Rooms, error) {
 // PostMessage sends message to gitter.
 func (client *RestAPIClient) PostMessage(ctx context.Context, room *Room, text string) (*Message, error) {
 	message := &Message{}
-	if err := client.Post(ctx, []string{"rooms", room.ID, "chatMessages"}, &PostingMessage{Text: text}, message); err != nil {
-		log.Error(err)
-		return nil, err
+	err := client.Post(ctx, []string{"rooms", room.ID, "chatMessages"}, &PostingMessage{Text: text}, message)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to post message: %w", err)
 	}
 	return message, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/tidwall/match v1.0.1 // indirect
 	github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65 // indirect
 	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6
+	golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373 h1:PPwnA7z1Pjf7XYaBP9GL1VAMZmcIWyFz7QCMSIIa3Bg=
+golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/plugins/worldweather/client.go
+++ b/plugins/worldweather/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
+	"golang.org/x/xerrors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -47,7 +48,7 @@ func (client *Client) buildEndpoint(apiType string, queryParams *url.Values) *ur
 
 	requestURL, err := url.Parse(fmt.Sprintf(weatherAPIEndpointFormat, apiType))
 	if err != nil {
-		panic(err.Error())
+		panic(xerrors.Errorf("failed to parse construct URL for %s: %w", apiType, err))
 	}
 	requestURL.RawQuery = queryParams.Encode()
 
@@ -59,21 +60,21 @@ func (client *Client) Get(ctx context.Context, apiType string, queryParams *url.
 	endpoint := client.buildEndpoint(apiType, queryParams)
 	resp, err := ctxhttp.Get(ctx, http.DefaultClient, endpoint.String())
 	if err != nil {
-		return err
+		return xerrors.Errorf("failed on GET request for %s: %w", apiType, err)
 	}
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("response status error. status: %d", resp.StatusCode)
+		return xerrors.Errorf("response status %d is returned", resp.StatusCode)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return xerrors.Errorf("failed to read response: %w", err)
 	}
 
 	if err := json.Unmarshal(body, data); err != nil {
-		return fmt.Errorf("failed to parse returned json data: %s", err.Error())
+		return xerrors.Errorf("failed to parse returned json data: %w", err)
 	}
 
 	return nil
@@ -85,7 +86,7 @@ func (client *Client) LocalWeather(ctx context.Context, location string) (*Local
 	queryParams.Add("q", location)
 	data := &LocalWeatherResponse{}
 	if err := client.Get(ctx, "weather", queryParams, data); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed getting weather data: %w", err)
 	}
 
 	return data, nil

--- a/plugins/worldweather/client_test.go
+++ b/plugins/worldweather/client_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -184,11 +185,8 @@ func TestClient_GetRequestError(t *testing.T) {
 		t.Fatal("Expected error is not returned.")
 	}
 
-	if urlErr, ok := err.(*url.Error); ok {
-		if urlErr.Err != expectedErr {
-			t.Errorf("Returned error differs from expectation: %#v, %#v.", err, expectedErr)
-		}
-	} else {
+	var urlErr *url.Error
+	if !xerrors.As(err, &urlErr) {
 		t.Errorf("Unexpected error is returned: %#v.", err)
 	}
 }

--- a/plugins/worldweather/weather.go
+++ b/plugins/worldweather/weather.go
@@ -71,7 +71,7 @@ func SlackCommandFunc(ctx context.Context, input sarah.Input, config sarah.Comma
 
 	// If error is returned with HTTP request level, just let it know and quit.
 	if err != nil {
-		log.Errorf("Error on weather api reqeust: %s.", err.Error())
+		log.Errorf("Error on weather api request: %+v", err)
 		return slack.NewStringResponse("Something went wrong with weather api request."), nil
 	}
 	// If status code of 200 is returned, which means successful API request, but still the content contains error message,

--- a/scheduler.go
+++ b/scheduler.go
@@ -1,10 +1,10 @@
 package sarah
 
 import (
-	"fmt"
 	"github.com/oklahomer/cron"
 	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"time"
 )
 
@@ -78,12 +78,12 @@ func (s *taskScheduler) receiveEvent(ctx context.Context) {
 	removeFunc := func(botType BotType, taskID string) error {
 		botSchedule, ok := schedule[botType]
 		if !ok {
-			return fmt.Errorf("registered task for %s is not found with ID of %s", botType.String(), taskID)
+			return xerrors.Errorf("registered task for %s is not found with ID of %s", botType, taskID)
 		}
 
 		storedID, ok := botSchedule[taskID]
 		if !ok {
-			return fmt.Errorf("task for %s is not found with ID of %s", botType.String(), taskID)
+			return xerrors.Errorf("task for %s is not found with ID of %s", botType, taskID)
 		}
 
 		delete(botSchedule, taskID)
@@ -95,7 +95,7 @@ func (s *taskScheduler) receiveEvent(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info("stop cron jobs due to context cancel")
+			log.Info("Stop cron jobs due to context cancel.")
 			s.cron.Stop()
 			return
 
@@ -104,7 +104,7 @@ func (s *taskScheduler) receiveEvent(ctx context.Context) {
 
 		case add := <-s.updatingTask:
 			if add.task.Schedule() == "" {
-				add.err <- fmt.Errorf("empty schedule is given for %s", add.task.Identifier())
+				add.err <- xerrors.Errorf("empty schedule is given for %s", add.task.Identifier())
 				continue
 			}
 

--- a/slack/adapter_test.go
+++ b/slack/adapter_test.go
@@ -3,15 +3,34 @@ package slack
 import (
 	"errors"
 	"github.com/oklahomer/go-sarah"
+	"github.com/oklahomer/go-sarah/log"
 	"github.com/oklahomer/go-sarah/retry"
 	"github.com/oklahomer/golack/rtmapi"
 	"github.com/oklahomer/golack/slackobject"
 	"github.com/oklahomer/golack/webapi"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
+	"io/ioutil"
+	stdLogger "log"
+	"os"
 	"reflect"
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	oldLogger := log.GetLogger()
+	defer log.SetLogger(oldLogger)
+
+	// Suppress log output in test by default
+	l := stdLogger.New(ioutil.Discard, "dummyLog", 0)
+	logger := log.NewWithStandardLogger(l)
+	log.SetLogger(logger)
+
+	code := m.Run()
+
+	os.Exit(code)
+}
 
 type DummyClient struct {
 	StartRTMSessionFunc func(context.Context) (*webapi.RTMStart, error)
@@ -139,7 +158,7 @@ func TestNewAdapter_WithOptionError(t *testing.T) {
 		t.Fatal("Expected error is not returned.")
 	}
 
-	if err != expectedErr {
+	if !xerrors.Is(err, expectedErr) {
 		t.Errorf("Unexpected error is returned: %s.", err.Error())
 	}
 

--- a/status.go
+++ b/status.go
@@ -1,14 +1,14 @@
 package sarah
 
 import (
-	"errors"
 	"github.com/oklahomer/go-sarah/log"
+	"golang.org/x/xerrors"
 	"sync"
 )
 
 var runnerStatus = &status{}
 
-var ErrRunnerAlreadyRunning = errors.New("go-sarah's process is already running")
+var ErrRunnerAlreadyRunning = xerrors.New("go-sarah's process is already running")
 
 func CurrentStatus() Status {
 	return runnerStatus.snapshot()
@@ -112,7 +112,7 @@ func (s *status) stop() {
 			// Comes here when channel is already closed.
 			// stop() is not expected to be called multiple times,
 			// but recover here to avoid panic.
-			log.Warn("Multiple status.stop() call occurred.")
+			log.Warn("Multiple status.stop() calls occurred.")
 		}
 	}()
 
@@ -142,7 +142,7 @@ func (bs *botStatus) stop() {
 			// Comes here when channel is already closed.
 			// stop() is not expected to be called multiple times,
 			// but recover here to avoid panic.
-			log.Warnf("Multiple botStatus.stop() call for %s occurred.", bs.botType)
+			log.Warnf("Multiple botStatus.stop() calls for %s occurred.", bs.botType)
 		}
 	}()
 

--- a/storage.go
+++ b/storage.go
@@ -1,10 +1,9 @@
 package sarah
 
 import (
-	"errors"
-	"fmt"
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"time"
 )
 
@@ -98,8 +97,10 @@ func (storage *defaultUserContextStorage) Get(key string) (ContextualFunc, error
 	switch v := val.(type) {
 	case *UserContext:
 		return v.Next, nil
+
 	default:
-		return nil, fmt.Errorf("cached value has illegal type of %T", v)
+		return nil, xerrors.Errorf("cached value has illegal type of %T", v)
+
 	}
 }
 
@@ -114,7 +115,7 @@ func (storage *defaultUserContextStorage) Delete(key string) error {
 // Stored context is tied to given key, which represents a particular user.
 func (storage *defaultUserContextStorage) Set(key string, userContext *UserContext) error {
 	if userContext.Next == nil {
-		return errors.New("UserContext.Next is not set. defaultUserContextStorage only supports in-memory ContextualFunc cache.")
+		return xerrors.New("required UserContext.Next is not set. defaultUserContextStorage only supports in-memory ContextualFunc cache.")
 	}
 
 	storage.cache.Set(key, userContext, cache.DefaultExpiration)

--- a/task.go
+++ b/task.go
@@ -1,9 +1,8 @@
 package sarah
 
 import (
-	"errors"
-	"fmt"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"os"
 	"reflect"
 	"sync"
@@ -11,10 +10,10 @@ import (
 
 var (
 	// ErrTaskInsufficientArgument is returned when required parameters are not set.
-	ErrTaskInsufficientArgument = errors.New("one or more of required fields -- BotType, Identifier or Func -- are empty")
+	ErrTaskInsufficientArgument = xerrors.New("one or more of required fields -- BotType, Identifier or Func -- are empty")
 
 	// ErrTaskScheduleNotGiven is returned when schedule is provided by neither ScheduledTaskPropsBuilder's parameter nor config.
-	ErrTaskScheduleNotGiven = errors.New("task schedule is not set or given from config struct")
+	ErrTaskScheduleNotGiven = xerrors.New("task schedule is not set or given from config struct")
 )
 
 // ScheduledTaskResult is a struct that ScheduledTask returns on its execution.
@@ -150,7 +149,7 @@ func buildScheduledTask(props *ScheduledTaskProps, file *pluginConfigFile) (Sche
 			return e
 		}()
 		if err != nil && os.IsNotExist(err) {
-			return nil, fmt.Errorf("config file property was given, but failed to locate it: %s", err.Error())
+			return nil, xerrors.Errorf("config file property was given, but failed to locate it: %w", err)
 		} else if err != nil {
 			// File was there, but could not read.
 			return nil, err
@@ -294,7 +293,7 @@ func (builder *ScheduledTaskPropsBuilder) Build() (*ScheduledTaskProps, error) {
 func (builder *ScheduledTaskPropsBuilder) MustBuild() *ScheduledTaskProps {
 	task, err := builder.Build()
 	if err != nil {
-		panic(fmt.Sprintf("Error on building ScheduledTaskProps: %s", err.Error()))
+		panic(xerrors.Errorf("error on building ScheduledTaskProps: %w", err))
 	}
 
 	return task

--- a/watchers/dirwatcher.go
+++ b/watchers/dirwatcher.go
@@ -4,17 +4,17 @@ Package watchers provides mechanism to subscribe events under given directory.
 package watchers
 
 import (
-	"errors"
 	"github.com/fsnotify/fsnotify"
 	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"path/filepath"
 )
 
 // ErrWatcherNotRunning is returned when method is called after Watcher context cancellation.
 // This error can safely be ignored when this is returned by Watcher.Unsubscribe
 // because the context and all subscriptions are already cancelled.
-var ErrWatcherNotRunning = errors.New("context is already canceled")
+var ErrWatcherNotRunning = xerrors.New("context is already canceled")
 
 // Watcher defines an interface that all file system watcher must satisfy.
 type Watcher interface {
@@ -97,7 +97,7 @@ func (w *watcher) supervise(ctx context.Context, events <-chan fsnotify.Event, e
 			if err == nil {
 				log.Info("Stop subscribing to file system event due to context cancel.")
 			} else {
-				log.Warnf("Error on subscription cancellation: %s.", err.Error())
+				log.Warnf("Error on subscription cancellation: %+v", err)
 			}
 
 			// Explicitly close unsubscribeGroup to make sure enqueueing does not block forever, but panics instead.
@@ -163,7 +163,7 @@ func (w *watcher) supervise(ctx context.Context, events <-chan fsnotify.Event, e
 			}
 
 		case err := <-errs:
-			log.Errorf("Error on subscribing to directory change: %s.", err.Error())
+			log.Errorf("Error on subscribing to directory change: %+v", err)
 
 		}
 	}

--- a/workers/worker.go
+++ b/workers/worker.go
@@ -4,10 +4,10 @@ Package workers provides general purpose worker mechanism that outputs stacktrac
 package workers
 
 import (
-	"errors"
 	"fmt"
 	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"runtime"
 	"strings"
 	"time"
@@ -15,10 +15,10 @@ import (
 
 var (
 	// ErrEnqueueAfterWorkerShutdown is returned when job is given after worker context cancellation.
-	ErrEnqueueAfterWorkerShutdown = errors.New("job can not be enqueued after worker shutdown")
+	ErrEnqueueAfterWorkerShutdown = xerrors.New("job can not be enqueued after worker shutdown")
 
 	// ErrQueueOverflow is returned when job is given, but all workers are busy and queue is full.
-	ErrQueueOverflow = errors.New("queue is full")
+	ErrQueueOverflow = xerrors.New("queue is full")
 )
 
 // Config contains some configuration variables.

--- a/workers/worker_test.go
+++ b/workers/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/net/context"
+	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	stdLogger "log"
@@ -168,8 +169,8 @@ func TestRun_ErrEnqueueAfterShutdown(t *testing.T) {
 
 	err = worker.Enqueue(func() {})
 
-	if err != ErrEnqueueAfterWorkerShutdown {
-		t.Errorf("Expected error is not returned: %T.", err)
+	if !xerrors.Is(err, ErrEnqueueAfterWorkerShutdown) {
+		t.Errorf("Expected error is not returned: %+v", err)
 	}
 }
 
@@ -197,8 +198,8 @@ func TestRun_ErrQueueOverflow(t *testing.T) {
 
 	// Next job should be blocked with no buffered channel.
 	err = worker.Enqueue(func() {})
-	if err != ErrQueueOverflow {
-		t.Errorf("Expected error is not returned: %T.", err)
+	if !xerrors.Is(err, ErrQueueOverflow) {
+		t.Errorf("Expected error is not returned: %+v", err)
 	}
 }
 


### PR DESCRIPTION
This solves #74.
- `errors.New()` -> `xerrors.New()`
- `fmt.Errorf()` -> `xerrors.Errorf()`
- Use `%+v` for log message format ... https://github.com/oklahomer/go-sarah/issues/74#issuecomment-491471182