### PR TITLE
Feature/improve coverage test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,20 @@ go:
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH
   - go get github.com/mattn/goveralls
+  - go get github.com/modocache/gover
 
 script:
   - go test -race ./...
-  - go test -coverprofile=coverage.out ./...
-  - goveralls -coverprofile=coverage.out -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
+  - go test -coverprofile=sarah.coverprofile .
+  - go test -coverprofile=alerter.line.coverprofile ./alerter/line
+  - go test -coverprofile=gitter.coverprofile ./gitter
+  - go test -coverprofile=log.coverprofile ./log
+  - go test -coverprofile=retry.coverprofile ./retry
+  - go test -coverprofile=slack.coverprofile ./slack
+  - go test -coverprofile=watchers.coverprofile ./watchers
+  - go test -coverprofile=workers.coverprofile ./workers
+  - gover
+  - goveralls -coverprofile=gover.coverprofile -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
 
 script:
   - go test -race ./...
-  - go test -cover ./...
-  - goveralls -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
+  - go test -coverprofile=coverage.out ./...
+  - goveralls -coverprofile=coverage.out -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
 
 matrix:
   allow_failures:


### PR DESCRIPTION
With current .travis.yml setting, [Golang 1.10.0+ environment cannot output coverage on some packages](https://coveralls.io/builds/24012860) and therefore coverage differs among Golang versions:

![image](https://user-images.githubusercontent.com/1629963/59548538-cdf32180-8f8b-11e9-9ccb-cc28bfcb0c77.png)

Since this project is composed of multiple packages and coverages for all packages need to be merged before being submitted to coveralls.io by goveralls. However, `go test -cover ./...` does not simply output coverage for all packages. [`go test -coverprofile=coverage.out ./...`](https://github.com/oklahomer/go-sarah/commit/8768919625c8061f9fc0ab6629d453e1b1ae435f) can output all coverage data to one file, but is only available from [Golang 1.10.0](https://golang.org/doc/go1.10#test). Another approach is to run `go test -coverprofile=UNIQUE_NAME.coverprofile TARGET_PKG` for each package and let `gover` merge all .coverprofile files before running `goveralls`.

With this setting, coverages for all packages are [reported as expected](https://coveralls.io/builds/24013025).
![image](https://user-images.githubusercontent.com/1629963/59548639-05ae9900-8f8d-11e9-976e-ab91767e6451.png)
