### PR TITLE
Provide an option to replace http.DefaultClient

### DIFF
--- a/alerter/line/client_test.go
+++ b/alerter/line/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -26,9 +27,24 @@ func TestNewConfig(t *testing.T) {
 	}
 }
 
+func TestWithHTTPClient(t *testing.T) {
+	httpClient := &http.Client{}
+	option := WithHTTPClient(httpClient)
+	client := &Client{}
+
+	option(client)
+
+	if client.httpClient != httpClient {
+		t.Error("Expected http client is not set.")
+	}
+}
+
 func TestNew(t *testing.T) {
+	optCalled := false
 	config := NewConfig()
-	client := New(config)
+	client := New(config, func(_ *Client) {
+		optCalled = true
+	})
 
 	if client == nil {
 		t.Fatal("Client struct is not returned.")
@@ -36,6 +52,10 @@ func TestNew(t *testing.T) {
 
 	if client.config == nil {
 		t.Fatal("Config is not set.")
+	}
+
+	if !optCalled {
+		t.Error("Given Option is not applied.")
 	}
 }
 
@@ -55,7 +75,7 @@ func TestClient_Alert(t *testing.T) {
 	}
 
 	for _, r := range responses {
-		http.DefaultClient = &http.Client{
+		httpClient := &http.Client{
 			Transport: roundTripFnc(func(req *http.Request) (*http.Response, error) {
 				if req.Method != "POST" {
 					t.Fatalf("Unexpected request method: %s.", req.Method)
@@ -72,7 +92,13 @@ func TestClient_Alert(t *testing.T) {
 			}),
 		}
 
-		client := New(NewConfig())
+		client := &Client{
+			config: &Config{
+				RequestTimeout: 3 * time.Second,
+				Token:          "dummy",
+			},
+			httpClient: httpClient,
+		}
 		err := client.Alert(context.TODO(), "DUMMY", errors.New("message"))
 		if r.Status == 200 && err != nil {
 			t.Errorf("Unexpected error is returned: %s.", err.Error())


### PR DESCRIPTION
This lets developers use custom configured http.Client for LINE alerter.