### PR TITLE
Remove return value from functional option

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -79,17 +79,14 @@ func NewBot(adapter Adapter, options ...DefaultBotOption) (Bot, error) {
 	}
 
 	for _, opt := range options {
-		err := opt(bot)
-		if err != nil {
-			return nil, err
-		}
+		opt(bot)
 	}
 
 	return bot, nil
 }
 
 // DefaultBotOption defines function that defaultBot's functional option must satisfy.
-type DefaultBotOption func(bot *defaultBot) error
+type DefaultBotOption func(bot *defaultBot)
 
 // BotWithStorage creates and returns DefaultBotOption to set preferred UserContextStorage implementation.
 // Below example utilizes pre-defined in-memory storage.
@@ -99,9 +96,8 @@ type DefaultBotOption func(bot *defaultBot) error
 //  yaml.Unmarshal(configBuf, config)
 //  bot, err := sarah.NewBot(myAdapter, storage)
 func BotWithStorage(storage UserContextStorage) DefaultBotOption {
-	return func(bot *defaultBot) error {
+	return func(bot *defaultBot) {
 		bot.userContextStorage = storage
-		return nil
 	}
 }
 

--- a/bot_test.go
+++ b/bot_test.go
@@ -36,62 +36,26 @@ func (bot *DummyBot) Run(ctx context.Context, enqueueInput func(Input) error, no
 	bot.RunFunc(ctx, enqueueInput, notifyErr)
 }
 
-func TestNewBot_WithoutFunctionalOption(t *testing.T) {
+func TestNewBot(t *testing.T) {
 	adapter := &DummyAdapter{}
-	myBot, err := NewBot(adapter)
-
-	if err != nil {
-		t.Fatalf("Unexpected error is returned: %#v.", err)
-	}
-
-	if _, ok := myBot.(*defaultBot); !ok {
-		t.Errorf("NewBot did not return bot instance: %#v.", myBot)
-	}
-}
-
-func TestNewBot_WithFunctionalOption(t *testing.T) {
-	adapter := &DummyAdapter{}
-	expectedErr := errors.New("this is expected")
-	myBot, err := NewBot(
-		adapter,
-		func(bot *defaultBot) error {
-			return nil
-		},
-		func(bot *defaultBot) error {
-			return expectedErr
-		},
-	)
-
-	if err == nil {
-		t.Fatal("Expected error is not returned")
-	}
-
-	if err != expectedErr {
-		t.Fatalf("Unexpected error is returned: %#v.", err)
-	}
-
-	if myBot != nil {
-		t.Fatalf("Bot should not be returned: %#v.", myBot)
-	}
-}
-
-func TestBotWithStorage(t *testing.T) {
 	storage := &DummyUserContextStorage{}
 	option := BotWithStorage(storage)
-
-	bot := &defaultBot{}
-	err := option(bot)
+	myBot, err := NewBot(
+		adapter,
+		option,
+	)
 
 	if err != nil {
-		t.Fatalf("Unexpected error is returned: %s", err.Error())
+		t.Fatalf("Unexpected error is returned: %#v.", err)
 	}
 
-	if bot.userContextStorage == nil {
-		t.Fatal("UserContextStorage is not set")
+	typedBot, ok := myBot.(*defaultBot)
+	if !ok {
+		t.Errorf("NewBot did not return defaultBot instance: %#v.", myBot)
 	}
 
-	if bot.userContextStorage != storage {
-		t.Fatalf("Expected UserContextStorage implementation is not set: %#v", bot.userContextStorage)
+	if typedBot.userContextStorage != storage {
+		t.Fatalf("Expected UserContextStorage implementation is not set: %#v", typedBot.userContextStorage)
 	}
 }
 

--- a/gitter/adapter.go
+++ b/gitter/adapter.go
@@ -14,7 +14,7 @@ const (
 )
 
 // AdapterOption defines function signature that Adapter's functional option must satisfy.
-type AdapterOption func(adapter *Adapter) error
+type AdapterOption func(adapter *Adapter)
 
 // Adapter stores REST/Streaming API clients' instances to let users interact with gitter.
 type Adapter struct {
@@ -32,10 +32,7 @@ func NewAdapter(config *Config, options ...AdapterOption) (*Adapter, error) {
 	}
 
 	for _, opt := range options {
-		err := opt(adapter)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to apply options: %w", err)
-		}
+		opt(adapter)
 	}
 
 	return adapter, nil

--- a/gitter/adapter_test.go
+++ b/gitter/adapter_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/oklahomer/go-sarah"
 	"github.com/oklahomer/go-sarah/log"
 	"github.com/oklahomer/go-sarah/retry"
-	"golang.org/x/xerrors"
 	"io/ioutil"
 	stdLogger "log"
 	"os"
@@ -64,28 +63,13 @@ func (c *DummyConnection) Close() error {
 
 func TestNewAdapter(t *testing.T) {
 	config := NewConfig()
-	adapter, err := NewAdapter(config)
+	adapter, err := NewAdapter(config, func(_ *Adapter) {})
 	if err != nil {
 		t.Fatalf("Unexpected error returned: %s.", err.Error())
 	}
 
 	if adapter.config != config {
 		t.Fatal("Supplied config is not set.")
-	}
-}
-
-func TestNewAdapter_WithOptionError(t *testing.T) {
-	expectedErr := errors.New("dummy")
-	adapter, err := NewAdapter(NewConfig(), func(_ *Adapter) error {
-		return expectedErr
-	})
-
-	if !xerrors.Is(err, expectedErr) {
-		t.Errorf("Expected error is not returned: %#v.", err)
-	}
-
-	if adapter != nil {
-		t.Error("Adapter instance should not be returned on error.")
 	}
 }
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -73,9 +73,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func Test_optionHolder_register(t *testing.T) {
-	opt := func(_ *runner) error {
-		return nil
-	}
+	opt := func(_ *runner) {}
 	holder := &optionHolder{}
 	holder.register(opt)
 
@@ -90,28 +88,18 @@ func Test_optionHolder_register(t *testing.T) {
 
 func Test_optionHandler_apply(t *testing.T) {
 	called := 0
-	expectedErr := errors.New("option application error")
 	holder := &optionHolder{}
-	holder.stashed = []func(*runner) error{
-		func(_ *runner) error {
+	holder.stashed = []func(*runner){
+		func(_ *runner) {
 			called++
-			return nil
 		},
-		func(_ *runner) error {
+		func(_ *runner) {
 			called++
-			return expectedErr
 		},
 	}
 	r := &runner{}
 
-	err := holder.apply(r)
-
-	if err == nil {
-		t.Fatal("Expected error is not returned.")
-	}
-	if err != expectedErr {
-		t.Errorf("Unexpected error is not returned: %s.", err.Error())
-	}
+	holder.apply(r)
 
 	if called != 2 {
 		t.Errorf("Unexpected number of options are applied: %d.", called)
@@ -127,10 +115,7 @@ func TestRegisterAlerter(t *testing.T) {
 		}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if len(*r.alerters) != 1 {
@@ -152,10 +137,7 @@ func TestRegisterBot(t *testing.T) {
 		}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if len(r.bots) != 1 {
@@ -178,10 +160,7 @@ func TestRegisterCommand(t *testing.T) {
 		}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if len(r.commands[botType]) != 1 {
@@ -206,10 +185,7 @@ func TestRegisterCommandProps(t *testing.T) {
 		}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if len(r.commandProps[botType]) != 1 {
@@ -232,10 +208,7 @@ func TestRegisterScheduledTask(t *testing.T) {
 		}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if len(r.scheduledTasks[botType]) != 1 {
@@ -260,10 +233,7 @@ func TestRegisterScheduledTaskProps(t *testing.T) {
 		}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if len(r.scheduledTaskProps[botType]) != 1 {
@@ -283,10 +253,7 @@ func TestRegisterConfigWatcher(t *testing.T) {
 		r := &runner{}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if r.configWatcher == nil {
@@ -306,10 +273,7 @@ func TestRegisterWorker(t *testing.T) {
 		r := &runner{}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if r.worker == nil {
@@ -330,10 +294,7 @@ func TestRegisterBotErrorSupervisor(t *testing.T) {
 		r := &runner{}
 
 		for _, v := range options.stashed {
-			err := v(r)
-			if err != nil {
-				t.Fatalf("Unexpected error is returned: %s.", err.Error())
-			}
+			v(r)
 		}
 
 		if r.superviseError == nil {
@@ -412,24 +373,6 @@ func Test_newRunner_WithTimeZoneError(t *testing.T) {
 	SetupAndRun(func() {
 		config := &Config{
 			TimeZone: "DUMMY",
-		}
-
-		_, e := newRunner(context.Background(), config)
-		if e == nil {
-			t.Fatal("Expected error is not returned.")
-		}
-	})
-}
-
-func Test_newRunner_WithOptionError(t *testing.T) {
-	SetupAndRun(func() {
-		config := &Config{
-			TimeZone: time.UTC.String(),
-		}
-		options.stashed = []func(*runner) error{
-			func(_ *runner) error {
-				return errors.New("dummy")
-			},
 		}
 
 		_, e := newRunner(context.Background(), config)

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -23,14 +23,13 @@ const (
 var pingSignalChannelID = "ping"
 
 // AdapterOption defines function signature that Adapter's functional option must satisfy.
-type AdapterOption func(adapter *Adapter) error
+type AdapterOption func(adapter *Adapter)
 
 // WithSlackClient creates AdapterOption with given SlackClient implementation.
 // If this option is not given, NewAdapter() tries to create golack instance with given Config.
 func WithSlackClient(client SlackClient) AdapterOption {
-	return func(adapter *Adapter) error {
+	return func(adapter *Adapter) {
 		adapter.client = client
-		return nil
 	}
 }
 
@@ -81,9 +80,8 @@ func WithSlackClient(client SlackClient) AdapterOption {
 //  slackAdapter, _ := slack.NewAdapter(slackConfig, slack.WithSlackClient(slackClient), slack.WithPayloadHandler(payloadHandler))
 //  slackBot, _ := sarah.NewBot(slackAdapter)
 func WithPayloadHandler(fnc func(context.Context, *Config, rtmapi.DecodedPayload, func(sarah.Input) error)) AdapterOption {
-	return func(adapter *Adapter) error {
+	return func(adapter *Adapter) {
 		adapter.payloadHandler = fnc
-		return nil
 	}
 }
 
@@ -114,10 +112,7 @@ func NewAdapter(config *Config, options ...AdapterOption) (*Adapter, error) {
 	}
 
 	for _, opt := range options {
-		err := opt(adapter)
-		if err != nil {
-			return nil, err
-		}
+		opt(adapter)
 	}
 
 	// See if client is set by WithSlackClient option.

--- a/slack/adapter_test.go
+++ b/slack/adapter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/oklahomer/golack/rtmapi"
 	"github.com/oklahomer/golack/slackobject"
 	"github.com/oklahomer/golack/webapi"
-	"golang.org/x/xerrors"
 	"io/ioutil"
 	stdLogger "log"
 	"os"
@@ -135,7 +134,7 @@ func TestNewAdapter_WithPayloadHandler(t *testing.T) {
 	opt := WithPayloadHandler(fnc)
 	adapter := &Adapter{}
 
-	_ = opt(adapter)
+	opt(adapter)
 
 	if adapter.payloadHandler == nil {
 		t.Fatal("PayloadHandler is not set.")
@@ -143,27 +142,6 @@ func TestNewAdapter_WithPayloadHandler(t *testing.T) {
 
 	if reflect.ValueOf(adapter.payloadHandler).Pointer() != reflect.ValueOf(fnc).Pointer() {
 		t.Fatal("Provided function is not set.")
-	}
-}
-
-func TestNewAdapter_WithOptionError(t *testing.T) {
-	config := &Config{}
-	expectedErr := errors.New("dummy")
-
-	adapter, err := NewAdapter(config, func(_ *Adapter) error {
-		return expectedErr
-	})
-
-	if err == nil {
-		t.Fatal("Expected error is not returned.")
-	}
-
-	if !xerrors.Is(err, expectedErr) {
-		t.Errorf("Unexpected error is returned: %s.", err.Error())
-	}
-
-	if adapter != nil {
-		t.Error("Adapter should not be returned.")
 	}
 }
 
@@ -653,10 +631,6 @@ func TestMessageInput(t *testing.T) {
 	}
 
 	input := &MessageInput{event: rtmMessage}
-
-	if input == nil {
-		t.Fatal("MessageInput instance is not returned.")
-	}
 
 	if input.SenderKey() != channelID+"|"+senderID {
 		t.Errorf("Unexpected SenderKey is retuned: %s.", input.SenderKey())

--- a/workers/worker.go
+++ b/workers/worker.go
@@ -62,13 +62,12 @@ func (*reporter) Report(_ context.Context, stats *Stats) {
 }
 
 // WorkerOption defines function that worker's functional option must satisfy.
-type WorkerOption func(*worker) error
+type WorkerOption func(*worker)
 
 // WithReporter creates and returns WorkerOption to set preferred Reporter implementation.
 func WithReporter(reporter Reporter) WorkerOption {
-	return func(w *worker) error {
+	return func(w *worker) {
 		w.reporter = reporter
-		return nil
 	}
 }
 
@@ -118,10 +117,7 @@ func Run(ctx context.Context, config *Config, options ...WorkerOption) (Worker, 
 	}
 
 	for _, opt := range options {
-		err := opt(w)
-		if err != nil {
-			return nil, err
-		}
+		opt(w)
 	}
 
 	log.Infof("Start spawning %d workers.", config.WorkerNum)

--- a/workers/worker_test.go
+++ b/workers/worker_test.go
@@ -3,7 +3,6 @@ package workers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/oklahomer/go-sarah/log"
 	"golang.org/x/xerrors"
@@ -105,11 +104,7 @@ func TestWithReporter(t *testing.T) {
 	option := WithReporter(reporter)
 
 	worker := &worker{}
-	err := option(worker)
-
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s.", err.Error())
-	}
+	option(worker)
 
 	if worker.reporter == nil {
 		t.Error("Given reporter is not set.")
@@ -209,15 +204,9 @@ func TestRun_WorkerOption(t *testing.T) {
 	defer cancelWorker()
 
 	var cnt int
-	expectedErr := errors.New("expected error")
 	opts := []WorkerOption{
-		func(*worker) error {
+		func(*worker) {
 			cnt++
-			return nil
-		},
-		func(*worker) error {
-			cnt++
-			return expectedErr
 		},
 	}
 	_, err := Run(workerCtx, &Config{}, opts...)
@@ -226,12 +215,8 @@ func TestRun_WorkerOption(t *testing.T) {
 		t.Fatalf("%d WorkerOptions are given, but executed %d time(s).", len(opts), cnt)
 	}
 
-	if err == nil {
-		t.Fatal("Error is not returned.")
-	}
-
-	if err != expectedErr {
-		t.Fatalf("Expected error is not returned: %s.", err.Error())
+	if err != nil {
+		t.Fatalf("Unexpected error is returned: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
Currently, some functional option in this project return error. This was to let options report an inoperative situation when this is executed to modify the behavior of an instance. They are, however, only used as setters to an instance's fields. The signature with error return value is cumbersome since the error check is mandatory. This can simply be removed.
If some kind of check is required, that can be done in the constructor function. In this way, not only the functional option's signature becomes simple, dependencies/relations among multiple fields can be checked at once.