### PR TITLE
Add linter to CI setting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Exclude some staticcheck messages
+    - linters:
+        - staticcheck
+      text: "SA1019:" # Ignore https://golang.org/doc/go1.12#regexp to support Golang 1.11 and older.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ before_install:
   - export PATH=$HOME/gopath/bin:$PATH
   - go get github.com/mattn/goveralls
   - go get github.com/modocache/gover
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 script:
+  - golangci-lint run
   - go test -race ./...
   - go test -coverprofile=sarah.coverprofile .
   - go test -coverprofile=alerter.line.coverprofile ./alerter/line

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -33,7 +33,6 @@ func TestRetry(t *testing.T) {
 
 	retryTests := []struct {
 		failCnt uint
-		err     error
 	}{
 		{
 			// Succeed on the last trial

--- a/runner.go
+++ b/runner.go
@@ -429,7 +429,6 @@ func (r *runner) registerCommands(botCtx context.Context, bot Bot) {
 		return func() {
 			log.Infof("Updating command: %s", p.identifier)
 			reg(p)
-			return
 		}
 	}
 
@@ -469,7 +468,6 @@ func (r *runner) registerScheduledTasks(botCtx context.Context, bot Bot) {
 		return func() {
 			log.Infof("Updating scheduled task: %s", p.identifier)
 			reg(p)
-			return
 		}
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -445,9 +445,7 @@ func Test_runner_runBot(t *testing.T) {
 			AppendCommandFunc: func(cmd Command) {
 				passedCommand <- cmd
 			},
-			RunFunc: func(_ context.Context, _ func(Input) error, _ func(error)) {
-				return
-			},
+			RunFunc: func(_ context.Context, _ func(Input) error, _ func(error)) {},
 		}
 
 		// Prepare command to be configured on the fly
@@ -620,7 +618,8 @@ func Test_runner_runBot_WithPanic(t *testing.T) {
 
 		// Let it run
 		rootCtx := context.Background()
-		runnerCtx, _ := context.WithCancel(rootCtx)
+		runnerCtx, cancel := context.WithCancel(rootCtx)
+		defer cancel()
 		finished := make(chan bool)
 		go func() {
 			r.runBot(runnerCtx, bot)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -56,12 +56,12 @@ func TestTaskScheduler_updateAndRemove(t *testing.T) {
 	}
 
 	var storedBotType BotType = "Foo"
-	if err := scheduler.update(storedBotType, task, func() { return }); err == nil {
+	if err := scheduler.update(storedBotType, task, func() {}); err == nil {
 		t.Fatal("Error should return on invalid schedule value.")
 	}
 
 	task.schedule = "@daily"
-	if err := scheduler.update(storedBotType, task, func() { return }); err != nil {
+	if err := scheduler.update(storedBotType, task, func() {}); err != nil {
 		t.Fatalf("Error is returned on valid schedule value: %s", err.Error())
 	}
 	time.Sleep(10 * time.Millisecond)
@@ -89,7 +89,7 @@ func TestTaskScheduler_updateWithEmptySchedule(t *testing.T) {
 	defer cancel()
 	scheduler := runScheduler(ctx, time.Local)
 
-	err := scheduler.update("dummy", &DummyScheduledTask{}, func() { return })
+	err := scheduler.update("dummy", &DummyScheduledTask{}, func() {})
 
 	if err == nil {
 		t.Error("Expected error is not returned.")


### PR DESCRIPTION
Employ https://github.com/golangci/golangci-lint to run a set of linter on each CI.