### PR TITLE
Follow golint instruction and fix document

### DIFF
--- a/gitter/adapter.go
+++ b/gitter/adapter.go
@@ -179,7 +179,7 @@ func RespWithNextSerializable(arg *sarah.SerializableArgument) RespOption {
 	}
 }
 
-// RespOptions defines function signature that NewResponse's functional option must satisfy.
+// RespOption defines function signature that NewResponse's functional option must satisfy.
 type RespOption func(*respOptions)
 
 type respOptions struct {

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -600,7 +600,7 @@ func RespWithUnfurlMedia(unfurl bool) RespOption {
 	}
 }
 
-// RespOptions defines function signature that NewResponse's functional option must satisfy.
+// RespOption defines function signature that NewResponse's functional option must satisfy.
 type RespOption func(*respOptions)
 
 type respOptions struct {

--- a/status.go
+++ b/status.go
@@ -8,8 +8,17 @@ import (
 
 var runnerStatus = &status{}
 
+// ErrRunnerAlreadyRunning indicates that sarah.Run() is already called and the process is already running.
+// When this is returned, a second or later activations are prevented so the initially activated process is still protected.
 var ErrRunnerAlreadyRunning = xerrors.New("go-sarah's process is already running")
 
+// CurrentStatus returns the current status of go-sarah.
+// This can still be called even if sarah.Run() is not called, yet.
+// So developers can safely build two different goroutines:
+//
+//   - One to setup bot configuration and call sarah.Run()
+//   - Another to periodically call sarah.CurrentStatus() and monitor status.
+//     When Status.Running is false and Status.Bots is empty, then bot is not initiated yet.
 func CurrentStatus() Status {
 	return runnerStatus.snapshot()
 }


### PR DESCRIPTION
This fixes below warnings.

![image](https://user-images.githubusercontent.com/1629963/60762941-d7603d00-a0a4-11e9-9a2b-f8773bd0fafd.png)

```
go-sarah/slack/adapter.go
Line 603: warning: comment on exported type RespOption should be of the form "RespOption ..." (with optional leading article) (golint)
go-sarah/gitter/adapter.go
Line 182: warning: comment on exported type RespOption should be of the form "RespOption ..." (with optional leading article) (golint)
go-sarah/status.go
Line 11: warning: exported var ErrRunnerAlreadyRunning should have comment or be unexported (golint)
Line 13: warning: exported function CurrentStatus should have comment or be unexported (golint)
```