### PR TITLE
Support Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ before_install:
   - export PATH=$HOME/gopath/bin:$PATH
   - go get github.com/mattn/goveralls
   - go get github.com/modocache/gover
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 script:
-  - golangci-lint run
   - go test -race ./...
   - go test -coverprofile=sarah.coverprofile .
   - go test -coverprofile=alerter.line.coverprofile ./alerter/line

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 go:
   - "1.11.4"
   - "1.12"
+  - "1.13"
   - "tip"
 
 before_install:


### PR DESCRIPTION
This p-r adds Golang 1.13 support to this project.
To avoid having a 1.13-specific issue introduced in https://github.com/golangci/golangci-lint/issues/595, this removes golangci-lint dependency from its travis-ci setting. This removal should not cause any trouble since [GolangCI.com](https://golangci.com/) integration for p-r review is already activated.