### PR TITLE
Revert workaround for coverage test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
 
 script:
   - go test -race ./...
-  - go test -cover ./...
-  - goveralls -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
+  - go test -coverprofile=coverage.out -cover ./...
+  - goveralls -coverprofile=coverage.out -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,11 @@ go:
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH
   - go get github.com/mattn/goveralls
-  - go get github.com/modocache/gover
 
 script:
   - go test -race ./...
-  - go test -coverprofile=sarah.coverprofile .
-  - go test -coverprofile=alerter.line.coverprofile ./alerter/line
-  - go test -coverprofile=gitter.coverprofile ./gitter
-  - go test -coverprofile=log.coverprofile ./log
-  - go test -coverprofile=retry.coverprofile ./retry
-  - go test -coverprofile=slack.coverprofile ./slack
-  - go test -coverprofile=watchers.coverprofile ./watchers
-  - go test -coverprofile=workers.coverprofile ./workers
-  - gover
-  - goveralls -coverprofile=gover.coverprofile -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
+  - go test -cover ./...
+  - goveralls -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,examples/*/*/*/*.go
 
 matrix:
   allow_failures:


### PR DESCRIPTION
#84 introduced a workaround to properly measure the coverage with Go 1.9 or older versions. This project no longer supports such old versions so it is now safe to revert changes made in #84.