### PR TITLE
Expose raw slack event

### DIFF
--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -262,7 +262,7 @@ func (adapter *Adapter) SendMessage(ctx context.Context, output sarah.Output) {
 // Input represents a Slack-specific implementation of sarah.Input.
 // Pass incoming payload to EventToInput for conversion.
 type Input struct {
-	payload         interface{}
+	Event           interface{}
 	senderKey       string
 	text            string
 	timestamp       *event.TimeStamp
@@ -295,7 +295,7 @@ func EventToInput(e interface{}) (sarah.Input, error) {
 	switch typed := e.(type) {
 	case *event.Message:
 		return &Input{
-			payload:         e,
+			Event:           e,
 			senderKey:       fmt.Sprintf("%s|%s", typed.ChannelID.String(), typed.UserID.String()),
 			text:            typed.Text,
 			timestamp:       typed.TimeStamp,
@@ -305,7 +305,7 @@ func EventToInput(e interface{}) (sarah.Input, error) {
 
 	case *event.ChannelMessage:
 		return &Input{
-			payload:         e,
+			Event:           e,
 			senderKey:       fmt.Sprintf("%s|%s", typed.ChannelID.String(), typed.UserID.String()),
 			text:            typed.Text,
 			timestamp:       typed.TimeStamp,

--- a/slack/adapter.go
+++ b/slack/adapter.go
@@ -19,6 +19,7 @@ const (
 	SLACK sarah.BotType = "slack"
 )
 
+// ErrNonSupportedEvent is returned when given event is not supported by this adapter.
 var ErrNonSupportedEvent = xerrors.New("event not supported")
 
 // AdapterOption defines function signature that Adapter's functional option must satisfy.

--- a/slack/adapter_test.go
+++ b/slack/adapter_test.go
@@ -350,7 +350,7 @@ func TestNewResponse(t *testing.T) {
 	}{
 		{
 			input: &Input{
-				payload:   &event.Message{},
+				Event:     &event.Message{},
 				channelID: "dummy",
 			},
 			message: "dummy message",
@@ -358,7 +358,7 @@ func TestNewResponse(t *testing.T) {
 		},
 		{
 			input: &Input{
-				payload:   &event.Message{},
+				Event:     &event.Message{},
 				channelID: "dummy",
 			},
 			message: "dummy message",
@@ -387,7 +387,7 @@ func TestNewResponse(t *testing.T) {
 		},
 		{
 			input: &Input{
-				payload:   &event.Message{},
+				Event:     &event.Message{},
 				channelID: "dummy",
 				timestamp: &event.TimeStamp{
 					Time:          now,
@@ -402,7 +402,7 @@ func TestNewResponse(t *testing.T) {
 		},
 		{
 			input: &Input{
-				payload:   &event.Message{},
+				Event:     &event.Message{},
 				channelID: "dummy",
 				timestamp: &event.TimeStamp{
 					Time:          now,
@@ -418,7 +418,7 @@ func TestNewResponse(t *testing.T) {
 		},
 		{
 			input: &Input{
-				payload:   &event.Message{},
+				Event:     &event.Message{},
 				channelID: "dummy",
 				timestamp: &event.TimeStamp{
 					Time:          now,
@@ -435,7 +435,7 @@ func TestNewResponse(t *testing.T) {
 		},
 		{
 			input: &Input{
-				payload:   &event.Message{},
+				Event:     &event.Message{},
 				channelID: "dummy",
 				timestamp: &event.TimeStamp{
 					Time:          time.Now(),

--- a/slack/eventsapi_test.go
+++ b/slack/eventsapi_test.go
@@ -102,8 +102,8 @@ func TestDefaultEventsPayloadHandler(t *testing.T) {
 				t.Fatalf("Unexpected input is given: %#v", input)
 			}
 
-			if typed.payload != ev {
-				t.Errorf("Given payload does not match with the original one: %#v", typed.payload)
+			if typed.Event != ev {
+				t.Errorf("Given event does not match with the original one: %#v", typed.Event)
 			}
 		}
 	})


### PR DESCRIPTION
Now Slack adapter wraps the original event data in `slack.Input` and provides some methods to satisfy `sarah.Input` interface. It would be better for Command/ScheduledTask developers to give access to the wrapped event.