### PR TITLE
Replace unnecessary uses of ioutil

### DIFF
--- a/gitter/rest.go
+++ b/gitter/rest.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/oklahomer/go-sarah/v3/log"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -70,12 +69,9 @@ func (client *RestAPIClient) Get(ctx context.Context, resourceFragments []string
 	defer resp.Body.Close()
 
 	// Handle response
-	body, err := ioutil.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&intf)
 	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(body, &intf); err != nil {
-		log.Errorf("Can not unmarshal given JSON structure: %s. Error: %+v", string(body), err)
+		log.Errorf("Can not unmarshal given JSON structure: %+v", err)
 		return err
 	}
 
@@ -111,12 +107,9 @@ func (client *RestAPIClient) Post(ctx context.Context, resourceFragments []strin
 	// TODO check status code
 
 	// Handle response
-	body, err := ioutil.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responsePayload)
 	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(body, &responsePayload); err != nil {
-		log.Errorf("Can not unmarshal given JSON structure: %s. Error: %+v", string(body), err)
+		log.Errorf("Can not unmarshal given JSON structure: %+v", err)
 		return err
 	}
 

--- a/watchers/filewatcher.go
+++ b/watchers/filewatcher.go
@@ -9,7 +9,6 @@ import (
 	"github.com/oklahomer/go-sarah/v3"
 	"github.com/oklahomer/go-sarah/v3/log"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,17 +69,18 @@ func (w *fileWatcher) Read(ctx context.Context, botType sarah.BotType, id string
 		}
 	}
 
-	buf, err := ioutil.ReadFile(file.absPath)
+	f, err := os.Open(file.absPath)
 	if err != nil {
 		return fmt.Errorf("failed to read configuration file at %s: %w", file.absPath, err)
 	}
+	defer f.Close()
 
 	switch file.fileType {
 	case yamlFile:
-		return yaml.Unmarshal(buf, configPtr)
+		return yaml.NewDecoder(f).Decode(configPtr)
 
 	case jsonFile:
-		return json.Unmarshal(buf, configPtr)
+		return json.NewDecoder(f).Decode(configPtr)
 
 	default:
 		// Should never come. findPluginConfigFile guarantees that.


### PR DESCRIPTION
This p-r replaces unnecessary uses of `ioutil` package with equivalent but more memory-efficient implementations, which includes the use of `io.Reader` resulting from `os.Open()`. 
However, those usages in examples or test cases are still left as-is.