### PR TITLE
Wrap error for better error handling

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -58,7 +58,7 @@ func (a *alerters) alertAll(ctx context.Context, botType BotType, err error) err
 
 			err := alerter.Alert(ctx, botType, err)
 			if err != nil {
-				errs.appendError(fmt.Errorf("failed to seend alert via %T: %w", alerter, err))
+				errs.appendError(fmt.Errorf("failed to send alert via %T: %w", alerter, err))
 			}
 		}()
 	}

--- a/alert_test.go
+++ b/alert_test.go
@@ -92,7 +92,7 @@ func TestAlerters_alertAll(t *testing.T) {
 		},
 		&DummyAlerter{
 			AlertFunc: func(_ context.Context, _ BotType, _ error) error {
-				return errors.New("error")
+				return wrappedErr
 			},
 		},
 		&DummyAlerter{
@@ -115,8 +115,18 @@ func TestAlerters_alertAll(t *testing.T) {
 		t.Fatalf("Expected 3 errors to be stored: %#v.", err)
 	}
 
-	e := errors.Unwrap((*typed)[0])
-	if e != wrappedErr {
-		t.Errorf("Expected error is not wrapped: %+v", e)
+	// The first error contains an error derived from panic
+	if !errors.Is((*typed)[0], wrappedErr) {
+		t.Errorf("Expected error is not wrapped: %+v", (*typed)[0])
+	}
+
+	// The second error contains a string derived from panic
+	if !strings.HasSuffix((*typed)[1].Error(), "PANIC!!") {
+		t.Errorf("Expected string is not wrapped: %+v", (*typed)[1])
+	}
+
+	// The third error wraps a error derived from Alerter.Alert
+	if !errors.Is((*typed)[2], wrappedErr) {
+		t.Errorf("Expected error is not wrapped: %+v", (*typed)[2])
 	}
 }

--- a/alerter/line/client.go
+++ b/alerter/line/client.go
@@ -68,7 +68,7 @@ func (c *Client) Alert(ctx context.Context, botType sarah.BotType, err error) er
 	v := url.Values{"message": {msg}}
 	req, err := http.NewRequest(http.MethodPost, Endpoint, strings.NewReader(v.Encode()))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to construct HTTP request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.config.Token)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -79,7 +79,7 @@ func (c *Client) Alert(ctx context.Context, botType sarah.BotType, err error) er
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed executing HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/gitter/rest.go
+++ b/gitter/rest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/oklahomer/go-sarah/v3/log"
 	"net/http"
 	"net/url"
 	"path"
@@ -53,7 +52,7 @@ func (client *RestAPIClient) Get(ctx context.Context, resourceFragments []string
 	endpoint := client.buildEndpoint(resourceFragments)
 	req, err := http.NewRequest("GET", endpoint.String(), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to construct HTTP request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+client.token)
 	req.Header.Set("Accept", "application/json")
@@ -63,7 +62,7 @@ func (client *RestAPIClient) Get(ctx context.Context, resourceFragments []string
 	// Do request
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed executing HTTP request: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -71,8 +70,7 @@ func (client *RestAPIClient) Get(ctx context.Context, resourceFragments []string
 	// Handle response
 	err = json.NewDecoder(resp.Body).Decode(&intf)
 	if err != nil {
-		log.Errorf("Can not unmarshal given JSON structure: %+v", err)
-		return err
+		return fmt.Errorf("can not unmarshal given JSON structure: %w", err)
 	}
 
 	// Done
@@ -83,14 +81,14 @@ func (client *RestAPIClient) Get(ctx context.Context, resourceFragments []string
 func (client *RestAPIClient) Post(ctx context.Context, resourceFragments []string, sendingPayload interface{}, responsePayload interface{}) error {
 	reqBody, err := json.Marshal(sendingPayload)
 	if err != nil {
-		return err
+		return fmt.Errorf("can not marshal given payload: %w", err)
 	}
 
 	// Set up sending request
 	endpoint := client.buildEndpoint(resourceFragments)
 	req, err := http.NewRequest("POST", endpoint.String(), strings.NewReader(string(reqBody)))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to construct HTTP request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+client.token)
 	req.Header.Set("Accept", "application/json")
@@ -99,7 +97,7 @@ func (client *RestAPIClient) Post(ctx context.Context, resourceFragments []strin
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed executing HTTP request: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -109,8 +107,7 @@ func (client *RestAPIClient) Post(ctx context.Context, resourceFragments []strin
 	// Handle response
 	err = json.NewDecoder(resp.Body).Decode(&responsePayload)
 	if err != nil {
-		log.Errorf("Can not unmarshal given JSON structure: %+v", err)
-		return err
+		return fmt.Errorf("can not unmarshal given JSON structure: %w", err)
 	}
 
 	// Done


### PR DESCRIPTION
This p-r tries to wrap errors when appropriate.
An error returned from another method/package is wrapped before being passed to the calling method when one or more of the below criteria meet.
- A public method internally delegates tasks to multiple methods, and different values of errors can be returned by each of them
- Wrapping errors in each layer increases traceability
- Adding some contextual information that a called method can not include can increase traceability