### PR TITLE
Create and use a logger adapter for robfig/cron

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/oklahomer/go-kasumi/logger"
 	"github.com/robfig/cron/v3"
+	"strings"
 	"time"
 )
 
@@ -52,10 +53,7 @@ type updatingTask struct {
 }
 
 func runScheduler(ctx context.Context, location *time.Location) scheduler {
-	c := cron.New(cron.WithLocation(location))
-	// TODO set logger
-	//c.ErrorLog = log.New(...)
-
+	c := cron.New(cron.WithLocation(location), cron.WithLogger(&cronLogAdapter{l: logger.GetLogger()}))
 	c.Start()
 
 	s := &taskScheduler{
@@ -119,4 +117,71 @@ func (s *taskScheduler) receiveEvent(ctx context.Context) {
 			add.err <- nil
 		}
 	}
+}
+
+type cronLogAdapter struct {
+	l logger.Logger
+}
+
+var _ cron.Logger = (*cronLogAdapter)(nil)
+
+func (c *cronLogAdapter) Info(msg string, keysAndValues ...interface{}) {
+	converted := c.convertKeyValues(keysAndValues)
+	args := append([]interface{}{msg}, converted...)
+	format := c.formatString(len(args))
+	c.l.Infof(format, args...)
+}
+
+func (c *cronLogAdapter) Error(err error, msg string, keysAndValues ...interface{}) {
+	converted := c.convertKeyValues(keysAndValues)
+	args := append([]interface{}{msg, "error", err}, converted...)
+	format := c.formatString(len(args))
+	c.l.Errorf(format, args...)
+}
+
+func (c *cronLogAdapter) convertKeyValues(keysAndValues []interface{}) []interface{} {
+	formatted := make([]interface{}, len(keysAndValues))
+	for i, arg := range keysAndValues {
+		switch typed := arg.(type) {
+		case time.Time:
+			str := typed.Format(time.RFC3339)
+			formatted[i] = str
+
+		case fmt.Stringer:
+			str := typed.String()
+			formatted[i] = str
+
+		default:
+			formatted[i] = typed
+
+		}
+	}
+
+	return formatted
+}
+
+func (c *cronLogAdapter) formatString(numKeysAndValues int) string {
+	var sb strings.Builder
+
+	// The first argument is always a stringified log message.
+	sb.WriteString("%s")
+
+	// Set a delimiter when there more arguments to follow.
+	// Note that the first element is already taken care of.
+	if numKeysAndValues > 1 {
+		sb.WriteString(", ")
+	}
+
+	// Arbitrary arguments are to be formatted with %v.
+	// robfig/cron's code suggests that the key is always string,
+	// but the type is actually interface{}.
+	// That library's logger implementation also format with %v, after all.
+	for i := 0; i < numKeysAndValues/2; i++ {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("%v=%v")
+	}
+
+	return sb.String()
 }


### PR DESCRIPTION
This p-r introduces a private struct called `cronLogAdapter` that implements robfig/cron's `Logger` interface and outputs logging messages to Sarah's logger.
This fixes #128.