### PR TITLE
Employ a workaround for Travis CI until Golang 1.15 support is gone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH
-  # A workaround until 1.15 is out and "go install" with version suffix is available for all supported Golang version
+  # A workaround until 1.15 support is removed and "go install" with version suffix is available for all supported Golang version
   # - go install github.com/mattn/goveralls@latest
   - ./ci/travis/before_install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ go:
 
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH
-  - go get github.com/mattn/goveralls
+  # A workaround until 1.15 is out and "go install" with version suffix is available for all supported Golang version
+  # - go install github.com/mattn/goveralls@latest
+  - ./ci/travis/before_install.sh
 
 script:
   - go test -race ./...

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# go version go1.17.5 darwin/arm64 -> 1.17
+GO_MINOR_VERSION=$(go version | grep -o 'go[0-9]\+\.[0-9]\+\(\[0-9]\+\)\?' | tr -d 'go')
+
+if [ "$GO_MINOR_VERSION" = "1.15" ] ; then
+    # "go get" and "go install" works, but version suffix is not supported yet.
+    eval "go install github.com/mattn/goveralls"
+else
+    # 1.16 or later version supports "go install" with version suffix.
+    # See https://tip.golang.org/doc/go1.16#tools
+    # "go install now accepts arguments with version suffixes (for example, go install example.com/cmd@v1.0.0).
+    # This causes go install to build and install packages in module-aware mode, ignoring the go.mod file in the
+    # current directory or any parent directory, if there is one.
+    #
+    # 1.17 now recommends the use of "go install" instead of "go get" to install commands outside the main module.
+    # See https://go.dev/doc/go1.17#go-get
+    # "go get prints a deprecation warning when installing commands outside the main module (without the -d flag).
+    # go install cmd@version should be used instead to install a command at a specific version, using a suffix like
+    # @latest or @v1.2.3. In Go 1.18, the -d flag will always be enabled, and go get will only be used to change
+    # dependencies in go.mod."
+    #
+    # 1.18 uses "go install" to install the latest version of an executable outside the context of the current module.
+    # See https://tip.golang.org/doc/go1.18#tools
+    # "To install the latest version of an executable outside the context of the current module, use go install
+    # example.com/cmd@latest. Any version query may be used instead of latest."
+    eval "go install github.com/mattn/goveralls@latest"
+fi


### PR DESCRIPTION
With its [policy](https://github.com/oklahomer/go-sarah#supported-golang-versions), go-sarah still needs to support Golang 1.15 until 1.18 is released.
This, however, causes an error on Travis CI integration when the job tries to install `github.com/mattn/goveralls` with `tip` version, saying "No command 'goveralls' found."
https://github.com/oklahomer/go-sarah/blob/54fc97a73d39763b867ab0f39d1aea57af861faf/.travis.yml#L12

With Golang 1.15, `go get` and `go install` both work.
With Golang 1.16, `go install` with version suffixes such as "@latest" is supported.
With Golang 1.17, `go install` is now preferred over `go get` to install commands outside the main module.
With Golang 1.18 ( or `tip` at this point, precisely ), the use of `go install` with version suffixes instead of `go get` is mandatory.

To support all versions listed above, this p-r introduces a workaround to install `github.com/mattn/goveralls`.
This workaround can be removed in the near future when Golang 1.18 is released and Golang 1.15 support is gone.
`go install github.com/mattn/goveralls@latest` should work, then.
