### PR TITLE
Update reportcard link for v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/oklahomer/go-sarah/v4.svg)](https://pkg.go.dev/github.com/oklahomer/go-sarah/v4)
 [![Go Report Card](https://goreportcard.com/badge/github.com/oklahomer/go-sarah)](https://goreportcard.com/report/github.com/oklahomer/go-sarah)
+[![Go Report Card](https://goreportcard.com/badge/github.com/oklahomer/go-sarah/v4)](https://goreportcard.com/report/github.com/oklahomer/go-sarah/v4)
 [![Build Status](https://app.travis-ci.com/oklahomer/go-sarah.svg?branch=master)](https://app.travis-ci.com/oklahomer/go-sarah)
 [![Coverage Status](https://coveralls.io/repos/github/oklahomer/go-sarah/badge.svg?branch=master)](https://coveralls.io/github/oklahomer/go-sarah?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a2f0df359bec1552b28f/maintainability)](https://codeclimate.com/github/oklahomer/go-sarah/maintainability)


### PR DESCRIPTION
The link to [Go Report Card](https://goreportcard.com/) directs to v1 of `go-sarah` instead of v4. This p-r updates this.