### PR TITLE
Fix CurrentStatus().Running remaining true after all bots stop

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -304,6 +304,7 @@ func (r *runner) run(ctx context.Context) {
 		}()
 	}
 	wg.Wait()
+	runnerStatus.stop()
 }
 
 func unsubscribeConfigWatcher(watcher ConfigWatcher, botType BotType) {

--- a/runner_test.go
+++ b/runner_test.go
@@ -321,6 +321,16 @@ func TestRun(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected error is not returned.")
 		}
+
+		// Wait for the runner goroutine spawned by Run() to finish.
+		// No bots are registered, so runner.run() returns almost immediately.
+		select {
+		case <-runnerStatus.finished:
+			// runner.run() has completed and called runnerStatus.stop().
+
+		case <-time.NewTimer(1 * time.Second).C:
+			t.Fatal("Runner goroutine did not finish in time.")
+		}
 	})
 }
 
@@ -404,7 +414,11 @@ func Test_runner_run(t *testing.T) {
 
 		rootCtx := context.Background()
 		ctx, cancel := context.WithCancel(rootCtx)
-		go r.run(ctx)
+		finished := make(chan struct{})
+		go func() {
+			r.run(ctx)
+			close(finished)
+		}()
 
 		time.Sleep(1 * time.Second)
 
@@ -423,7 +437,14 @@ func Test_runner_run(t *testing.T) {
 		}
 
 		cancel()
-		time.Sleep(1 * time.Second)
+
+		select {
+		case <-finished:
+			// r.run() has fully returned, including runnerStatus.stop()
+
+		case <-time.NewTimer(1 * time.Second).C:
+			t.Fatal("runner.run did not return in time.")
+		}
 
 		currentStatus := CurrentStatus()
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -425,8 +425,13 @@ func Test_runner_run(t *testing.T) {
 		cancel()
 		time.Sleep(1 * time.Second)
 
-		if CurrentStatus().Bots[0].Running {
+		currentStatus := CurrentStatus()
+
+		if currentStatus.Bots[0].Running {
 			t.Error("BotStatus.Running should not be true at this point.")
+		}
+		if currentStatus.Running {
+			t.Error("Status.Running should be false after all bots stop.")
 		}
 	})
 


### PR DESCRIPTION
# Summary                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                           
- Fix a latent bug where `CurrentStatus().Running` remains true after all bots have stopped, by calling runnerStatus.stop() at the end of `runner.run()`
- Add a regression assertion in `Test_runner_run` to verify `Status.Running` becomes false after all bots finish

# Details

 `status.stop()` (status.go:127) exists to close the finished channel and signal that the runner has stopped. Its counterpart `status.start()` is called at the beginning of `Run()`, but `stop()` was never called from production code.

  After all bots stopped and `runner.run()` returned, runnerStatus.finished remained an open, non-nil channel. This caused `running()` to take the default branch in its select statement and return `true` — making `CurrentStatus().Running` report the runner as still active when nothing was actually running.

  The fix adds a single `runnerStatus.stop()` call after `wg.Wait()` in `runner.run()`, symmetrically closing the lifecycle that `start()` opens.

# Test plan

- Existing `Test_runner_run` extended to assert `CurrentStatus().Running == false` after bots stop
- All existing tests pass: go `test --race ./...`